### PR TITLE
fix #63

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -72,6 +72,7 @@
    ["as"        (token+ `AS-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["assert"    (token+ `ASSERT-TOK "" lexeme "" lexeme-start lexeme-end)]    
    ["but"       (token+ `BUT-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["chaff"     (token+ `CHAFF-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["check"     (token+ `CHECK-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["disj"      (token+ `DISJ-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["else"      (token+ `ELSE-TOK "" lexeme "" lexeme-start lexeme-end)]  
@@ -106,6 +107,7 @@
    ["two"       (token+ `TWO-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["univ"      (token+ `UNIV-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["unsat"     (token+ `UNSAT-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["wheat"     (token+ `WHEAT-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["break"     (token+ `BREAK-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
    ["state"     (token+ `STATE-TOK "" lexeme "" lexeme-start lexeme-end)]

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -37,7 +37,8 @@ Decl : DISJ-TOK? NameList /COLON-TOK DISJ-TOK? SET-TOK? Expr
 ; Remember that a preceding / means to cut the token; it won't get included in the AST.
 ArrowDecl : DISJ-TOK? VAR-TOK? NameList /COLON-TOK DISJ-TOK? ArrowMult ArrowExpr
 FactDecl : FACT-TOK Name? Block
-PredDecl : /PRED-TOK (QualName DOT-TOK)? Name ParaDecls? Block
+PredType : WHEAT-TOK | CHAFF-TOK
+PredDecl : /PRED-TOK PredType? (QualName DOT-TOK)? Name ParaDecls? Block
 FunDecl : /FUN-TOK (QualName DOT-TOK)? Name ParaDecls? /COLON-TOK Expr Block
 ParaDecls : /LEFT-PAREN-TOK @DeclList? /RIGHT-PAREN-TOK 
           | /LEFT-SQUARE-TOK @DeclList? /RIGHT-SQUARE-TOK

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -28,6 +28,9 @@
 ;       * ...
 ;     * node/formula/quantified (TODO FILL)  -- quantified formula
 ;     * node/formula/multiplicity (TODO FILL) -- multiplicity formula
+;     * node/formula/sealed
+;       * wheat
+;       * chaff
 ;   * node/int -- integer expression
 ;     * node/int/op (children)
 ;       * node/int/op/add
@@ -474,8 +477,6 @@
 (define-syntax false (lambda (stx) (syntax-case stx ()    
     [val (identifier? (syntax val)) (quasisyntax/loc stx (node/formula/constant (nodeinfo #,(build-source-location stx)) 'false))])))
 
-
-
 ;; -- operators ----------------------------------------------------------------
 
 ; Should never be directly instantiated
@@ -654,6 +655,26 @@
      (quasisyntax/loc stx
        (let* ([x1 (node/expr/quantifier-var (nodeinfo #,(build-source-location stx)) (node/expr-arity r1) 'x1)] ...)
          (sum-quant-expr (nodeinfo #,(build-source-location stx)) (list (cons x1 r1) ...) int-expr)))]))
+
+;; -- sealing (for examplar) -----------------------------------------------------------
+
+(define (simple-write-proc str)
+  (lambda (v port mode)
+    (fprintf port "#<~a>" str)))
+
+(struct node/formula/sealed node/formula []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "node/formula/sealed"))])
+(struct wheat node/formula/sealed []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "wheat"))]
+  #:extra-constructor-name make-wheat)
+(struct chaff node/formula/sealed []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "chaff"))]
+  #:extra-constructor-name make-chaff)
+
+(define (unseal-node/formula x)
+  (if (node/formula/sealed? x)
+    (node-info x)
+    x))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -735,24 +735,35 @@ Returns whether the given run resulted in sat or unsat, respectively.
         (~@ (check-temporal-for-var is-var true-name))
        (update-state! (state-add-relation curr-state true-name name true-sigs true-breaker))))]))
 
+(begin-for-syntax
+  (define-splicing-syntax-class pred-type
+    #:description "optional pred flag"
+    #:attributes ((seal 0))
+    (pattern wheat
+      #:attr seal #'make-wheat)
+    (pattern chaff
+      #:attr seal #'make-chaff)
+    (pattern (~seq)
+      #:attr seal #'values)))
+
 ; Declare a new predicate
 ; (pred info name cond ...)
 ; (pred info (name var ...) cond ...)
 ;   or same without info
 (define-syntax (pred stx)
   (syntax-parse stx
-    [(pred name:id conds:expr ...+)
+    [(pred t:pred-type name:id conds:expr ...+)
      (quasisyntax/loc stx
        (begin
          ; use srcloc of actual predicate, not this location in sigs
-         (define name (&&/info (nodeinfo #,(build-source-location stx)) conds ...))
+         (define name (t.seal (&&/info (nodeinfo #,(build-source-location stx)) conds ...)))
          (update-state! (state-add-pred curr-state 'name name))))]
-    [(pred (name:id args:id ...+) conds:expr ...+)
+    [(pred t:pred-type (name:id args:id ...+) conds:expr ...+)
      (quasisyntax/loc stx
-       (begin 
-         (define (name args ...) (&&/info (nodeinfo #,(build-source-location stx)) conds ...))
+       (begin
+         (define (name args ...) (t.seal (&&/info (nodeinfo #,(build-source-location stx)) conds ...)))
          (update-state! (state-add-pred curr-state 'name name))))]))
-                                   
+
 ; Declare a new function
 ; (fun (name var ...) result)
 (define-syntax (fun stx)
@@ -925,7 +936,7 @@ Returns whether the given run resulted in sat or unsat, respectively.
   (syntax-parse stx
     [(with (ids:id ... #:from module-name) exprs ...+)
       #'(let ([temp-state curr-state])
-          (define ids (dynamic-require module-name 'ids)) ...
+          (define ids (unseal-node/formula (dynamic-require module-name 'ids))) ...
           (define result
             (let () exprs ...))
           (update-state! temp-state)

--- a/forge/translate-to-kodkod-cli.rkt
+++ b/forge/translate-to-kodkod-cli.rkt
@@ -42,6 +42,8 @@
      (print-cmd-cont ") ")
      (interpret-formula form relations atom-names new-quantvars)
      (print-cmd-cont ")")]
+    [(node/formula/sealed info)
+     (interpret-formula info relations atom-names quantvars)]
 
      ; (let ([quantvars (cons var quantvars)])
      ;   ( print-cmd-cont (format "(~a ([~a : ~a " quantifier (v (get-var-idx var quantvars)) (if (@> (node/expr-arity var) 1) "set" "one")))


### PR DESCRIPTION
- introduce a new "sealed" node/formula struct
- unwrap seals in check-ex-spec
- new syntax to make seals = "pred wheat ...." "pred chaff ...."

I don't know whether the kodkod change is right ...
 can students get extra info with the current unwrapping?

- - -

Anyway for now, here's an example:

#### wheat "utree.rkt"
```
#lang forge

sig Node {edges: set Node}

pred wheat isUndirectedTree {
    -- Symmetric
    edges = ~edges
	
    -- Connected
    Node->Node in *edges

    -- Do not allow self-loops
    no iden & edges
  
    -- Minimally connected - there aren't multiple paths from one node to another.
    all n : Node | {
        all m : Node | {
            (n->m + m->n) in edges implies (n->m + m->n) not in ^(edges - (n->m + m->n))
        }
    }
}

run {isUndirectedTree} for 7 Node
```

#### student code "main.rkt"

```
#lang forge/core

(require "utree.rkt")

isUndirectedTree
;; prints #<wheat>
```