### PR TITLE
fix #63

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -72,6 +72,7 @@
    ["as"        (token+ `AS-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["assert"    (token+ `ASSERT-TOK "" lexeme "" lexeme-start lexeme-end)]    
    ["but"       (token+ `BUT-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["chaff"     (token+ `CHAFF-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["check"     (token+ `CHECK-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["disj"      (token+ `DISJ-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["else"      (token+ `ELSE-TOK "" lexeme "" lexeme-start lexeme-end)]  
@@ -106,6 +107,7 @@
    ["two"       (token+ `TWO-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["univ"      (token+ `UNIV-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["unsat"     (token+ `UNSAT-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["wheat"     (token+ `WHEAT-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["break"     (token+ `BREAK-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
    ["state"     (token+ `STATE-TOK "" lexeme "" lexeme-start lexeme-end)]

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -37,7 +37,8 @@ Decl : DISJ-TOK? NameList /COLON-TOK DISJ-TOK? SET-TOK? Expr
 ; Remember that a preceding / means to cut the token; it won't get included in the AST.
 ArrowDecl : DISJ-TOK? VAR-TOK? NameList /COLON-TOK DISJ-TOK? ArrowMult ArrowExpr
 FactDecl : FACT-TOK Name? Block
-PredDecl : /PRED-TOK (QualName DOT-TOK)? Name ParaDecls? Block
+PredType : WHEAT-TOK | CHAFF-TOK
+PredDecl : /PRED-TOK PredType? (QualName DOT-TOK)? Name ParaDecls? Block
 FunDecl : /FUN-TOK (QualName DOT-TOK)? Name ParaDecls? /COLON-TOK Expr Block
 ParaDecls : /LEFT-PAREN-TOK @DeclList? /RIGHT-PAREN-TOK 
           | /LEFT-SQUARE-TOK @DeclList? /RIGHT-SQUARE-TOK

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -28,6 +28,9 @@
 ;       * ...
 ;     * node/formula/quantified (TODO FILL)  -- quantified formula
 ;     * node/formula/multiplicity (TODO FILL) -- multiplicity formula
+;     * node/formula/sealed
+;       * wheat
+;       * chaff
 ;   * node/int -- integer expression
 ;     * node/int/op (children)
 ;       * node/int/op/add
@@ -514,8 +517,6 @@
 (define-syntax false (lambda (stx) (syntax-case stx ()    
     [val (identifier? (syntax val)) (quasisyntax/loc stx (node/formula/constant (nodeinfo #,(build-source-location stx)) 'false))])))
 
-
-
 ;; -- operators ----------------------------------------------------------------
 
 ; Should never be directly instantiated
@@ -694,6 +695,26 @@
      (quasisyntax/loc stx
        (let* ([x1 (node/expr/quantifier-var (nodeinfo #,(build-source-location stx)) (node/expr-arity r1) 'x1)] ...)
          (sum-quant-expr (nodeinfo #,(build-source-location stx)) (list (cons x1 r1) ...) int-expr)))]))
+
+;; -- sealing (for examplar) -----------------------------------------------------------
+
+(define (simple-write-proc str)
+  (lambda (v port mode)
+    (fprintf port "#<~a>" str)))
+
+(struct node/formula/sealed node/formula []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "node/formula/sealed"))])
+(struct wheat node/formula/sealed []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "wheat"))]
+  #:extra-constructor-name make-wheat)
+(struct chaff node/formula/sealed []
+  #:methods gen:custom-write [(define write-proc (simple-write-proc "chaff"))]
+  #:extra-constructor-name make-chaff)
+
+(define (unseal-node/formula x)
+  (if (node/formula/sealed? x)
+    (node-info x)
+    x))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -213,9 +213,18 @@
               (~optional name:NameClass)
               block:BlockClass)))
 
-  ; PredDecl : /PRED-TOK (QualName DOT-TOK)? Name ParaDecls? Block
+  (define-syntax-class PredTypeClass
+    #:datum-literals (PredType)
+    #:attributes (sym)
+    (pattern (PredType "wheat")
+      #:attr sym #'wheat)
+    (pattern (PredType "chaff")
+      #:attr sym #'chaff))
+
+  ; PredDecl : /PRED-TOK PredType? (QualName DOT-TOK)? Name ParaDecls? Block
   (define-syntax-class PredDeclClass
     (pattern ((~literal PredDecl)
+              (~optional :PredTypeClass)
               (~optional (~seq prefix:QualNameClass "."))
               name:NameClass
               (~optional decls:ParaDeclsClass)
@@ -602,19 +611,21 @@
   [((~literal FactDecl) _ ...)
    (syntax/loc stx (raise "Facts are not allowed in #lang forge."))]))
 
-; PredDecl : /PRED-TOK (QualName DOT-TOK)? Name ParaDecls? Block
+; PredDecl : /PRED-TOK PredType? (QualName DOT-TOK)? Name ParaDecls? Block
 (define-syntax (PredDecl stx)
   (syntax-parse stx
-  [((~literal PredDecl) (~optional (~seq prefix:QualNameClass "."))
+  [((~literal PredDecl) (~optional t:PredTypeClass)
+                        (~optional (~seq prefix:QualNameClass "."))
                         name:NameClass
                         block:BlockClass)
    (with-syntax ([block (my-expand #'block)])
      (quasisyntax/loc stx (begin
        (~? (raise (format "Prefixes not allowed: ~a" 'prefix)))
        ; preserve stx location in Racket *sub*expression
-       #,(syntax/loc stx (pred name.name block)))))]
+       #,(syntax/loc stx (pred (~? t.sym) name.name block)))))]
 
-  [((~literal PredDecl) (~optional (~seq prefix:QualNameClass "."))
+  [((~literal PredDecl) (~optional t:PredTypeClass)
+                        (~optional (~seq prefix:QualNameClass "."))
                         name:NameClass
                         decls:ParaDeclsClass
                         block:BlockClass)
@@ -624,7 +635,7 @@
      (quasisyntax/loc stx (begin
        (~? (raise (format "Prefixes not allowed: ~a" 'prefix)))
        ; preserve stx location in Racket *sub*expression
-       #,(syntax/loc stx (pred decl block)))))]))
+       #,(syntax/loc stx (pred (~? t.sym) decl block)))))]))
 
 ; FunDecl : /FUN-TOK (QualName DOT-TOK)? Name ParaDecls? /COLON-TOK Expr Block
 (define-syntax (FunDecl stx)

--- a/forge/last-checker.rkt
+++ b/forge/last-checker.rkt
@@ -44,6 +44,10 @@
      (let ([new-quantvars (append (map assocify decls) quantvars)])       
        ; CHECK: recur into subformula
        (checkFormula run-or-state subform new-quantvars))]    
+
+    [(node/formula/sealed info)
+     (checkFormula run-or-state info quantvars)]
+
     [else (error (format "no matching case in checkFormula for ~a" formula))]))
 
 (define (assocify a-pair)  

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -390,9 +390,9 @@
   (define-splicing-syntax-class pred-type
     #:description "optional pred flag"
     #:attributes ((seal 0))
-    (pattern wheat
+    (pattern (~datum wheat)
       #:attr seal #'make-wheat)
-    (pattern chaff
+    (pattern (~datum chaff)
       #:attr seal #'make-chaff)
     (pattern (~seq)
       #:attr seal #'values)))

--- a/forge/translate-to-kodkod-cli.rkt
+++ b/forge/translate-to-kodkod-cli.rkt
@@ -42,6 +42,8 @@
      (print-cmd-cont ") ")
      (interpret-formula run-or-state form relations atom-names new-quantvars)
      (print-cmd-cont ")")]
+    [(node/formula/sealed info)
+     (interpret-formula info relations atom-names quantvars)]
 
      ; (let ([quantvars (cons var quantvars)])
      ;   ( print-cmd-cont (format "(~a ([~a : ~a " quantifier (v (get-var-idx var quantvars)) (if (@> (node/expr-arity var) 1) "set" "one")))


### PR DESCRIPTION
(moved from #68)

- introduce a new "sealed" node/formula struct
- unwrap seals in check-ex-spec
- new syntax to make seals = "pred wheat ...." "pred chaff ...."

The kodkod change means that staff AND students can `run` these predicates.

- - -

Anyway for now, here's an example:

#### wheat "utree.rkt"
```
#lang forge

sig Node {edges: set Node}

pred wheat isUndirectedTree {
    -- Symmetric
    edges = ~edges
	
    -- Connected
    Node->Node in *edges

    -- Do not allow self-loops
    no iden & edges
  
    -- Minimally connected - there aren't multiple paths from one node to another.
    all n : Node | {
        all m : Node | {
            (n->m + m->n) in edges implies (n->m + m->n) not in ^(edges - (n->m + m->n))
        }
    }
}

run {isUndirectedTree} for 7 Node
```

#### student code "main.rkt"

```
#lang forge/core

(require "utree.rkt")

isUndirectedTree
;; prints #<wheat>
```