### PR TITLE
[minor] Semantic versioner patch

### DIFF
--- a/.github/workflows/semanticVersionUpdater.yml
+++ b/.github/workflows/semanticVersionUpdater.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: '3.8'
         architecture: 'x64'
     - name: Get version
-      run: echo "::set-env name=UPDATE_TYPE::$(python .github/workflows/semanticVersionUpdater/get-update-type.py ${{ github.event.pull_request.title }})"
+      run: echo "UPDATE_TYPE=$(python .github/workflows/semanticVersionUpdater/get-update-type.py ${{ github.event.pull_request.title }})" >> $GITHUB_ENV
     - name: Update version
-      run: echo "::set-env name=NEW_VERSION::$(python .github/workflows/semanticVersionUpdater/read-version.py forge/info.rkt $UPDATE_TYPE)"
+      run: echo "NEW_VERSION=$(python .github/workflows/semanticVersionUpdater/read-version.py forge/info.rkt $UPDATE_TYPE)" >> $NEW_VERSION
     - name: Commit files
       run: |
         git add .


### PR DESCRIPTION
Github has deprecated using `set-env` in favor of the new approach detailed here: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

Updated to use the new approach.