### PR TITLE
logging: don't log during DrRacket background expansion

### DIFF
--- a/forge/logging/logging.rkt
+++ b/forge/logging/logging.rkt
@@ -22,8 +22,8 @@
        (regexp-match? #rx"forbidden .* access" (exn-message x))))
 
 (define (safe-make-parent-directory* filename)
-  ;; TODO try to set permissions before returning #false
-  (with-handlers ([exn:fail:filesystem? (lambda (x) #false)])
+  (with-handlers ([exn:fail? (lambda (x) #false)])
+    (file-or-directory-permissions (path-only filename) #o777)
     (make-parent-directory* filename)
     filename))
 

--- a/forge/logging/logging.rkt
+++ b/forge/logging/logging.rkt
@@ -135,9 +135,9 @@
   (define user (read peek-port))
   (close-input-port peek-port)
 
-  (if (and (string? project) (string? user) (path-string? user-data-file))
-      (let ()
-        (logging-on? #t)
+  (if (and (string? project) (string? user))
+      (let ((got-data-file? (path-string? user-data-file)))
+        (logging-on? got-data-file?)
         (read port)
         (read port)
         (define filename (format "~a" path))
@@ -149,16 +149,17 @@
         (define raw (file->string filename))
         (define mode (format "~a" language))
 
-        (verify-header user project filename)
+        (when got-data-file?
+          (verify-header user project filename)
 
-        (write-log (hash 'log-type "execution"
-                         'user user
-                         'filename logged-name
-                         'project project
-                         'time time
-                         'raw raw
-                         'mode mode))
-        (values #t project user))
+          (write-log (hash 'log-type "execution"
+                           'user user
+                           'filename logged-name
+                           'project project
+                           'time time
+                           'raw raw
+                           'mode mode)))
+        (values got-data-file? project user))
 
       (let ()
         (logging-on? #f)


### PR DESCRIPTION
Students were seeing errors like this:
```
  call-with-output-file: forbidden (write delete) access to C:\Users\MY-USERNAME\AppData\Local\forge\user-data.json
```

I could see the same errors by:

- opening a new file in DrRacket,
- adding a project name + username (to enable logging),
- typing a few characters (... don't click run)
- waiting for background expansion & looking for red text

The problem is that DrRacket's background expander is running. The expander
disables file-write access, but we don't want to log during expansion anyway.

This patch checks for background expansion and if so, disables logging.