### PR TITLE
logging: serialize tests at compile-time

### DIFF
--- a/forge/logging/logging.rkt
+++ b/forge/logging/logging.rkt
@@ -276,7 +276,7 @@
 ;             "bounds": ["..."],
 ;         },
 ; }
-(define (log-test test expected passed command data)
+(define (log-test test expected passed command-str data)
   (when (logging-on?)
 
     (define sigs (map (compose symbol->string Sig-name)
@@ -285,7 +285,7 @@
                            (get-relations test)))
 
     (write-log (hash 'log-type "test"
-                     'raw (format "~a" command)
+                     'raw command-str
                      'expected (symbol->string expected)
                      'passed passed
                      'data data


### PR DESCRIPTION
On slack, Ben R. found a problem ... some LTL programs fail to compile because of a marshalling error.

Here's an example program:

```
#lang forge
test expect {
    aTest : {
        always true
    } is sat
}
```

Running `raco make ....` gives an error like this one:

```
"ltl.rkt":
  making #<path:/Users/ben/code/racket/fork/extra-pkgs/Forge/issue-marshal/ltl.rkt>
  making #<path:/Users/ben/code/racket/fork/extra-pkgs/Forge/forge/main.rkt>
write: cannot marshal value that is embedded in compiled code
  value: (srcloc #<path:/Users/ben/code/racket/fork/extra-pkgs/Forge/issue-marshal/ltl.rkt> 5 8 78 11)
  context...:
   "/Applications/Racket-7.9-BC/collects/raco/raco.rkt": [running body]
   "/Applications/Racket-7.9-BC/collects/raco/main.rkt": [running body]
```

The problem is that we're trying to embed a compile-time struct, `srcloc`, into the run-time code.

I don't know why we're trying to do that, but I do know these `srcloc` appear in the AST to track source locations. The idea is that forge syntax gets parsed to a data structure that also holds srclocs.

PS calling `build-source-location-list` gives a serializable result instead of a srcloc struct

- - -

This PR avoids the serializing by turning tests into a string at compile-time instead of run-time.

I'm still not sure what else besides LTL can have this issue ... only that the "macro constructor" in `define-node-op` is making the `srcloc` struct in the example above. But either way, this PR should hide the problem.
