### PR TITLE
logging: do not gzip check-ex-spec logs

### DIFF
--- a/forge/logging/check-ex-spec/main.rkt
+++ b/forge/logging/check-ex-spec/main.rkt
@@ -18,10 +18,9 @@
   net/uri-codec
   net/url
   racket/list
-  (only-in file/gzip gzip-through-ports)
   (only-in racket/format ~s ~r)
-  (only-in racket/file make-parent-directory*)
-  (only-in racket/port with-input-from-string call-with-output-string)
+  (only-in racket/file make-parent-directory* file->string)
+  (only-in racket/port with-input-from-string)
   (only-in racket/path file-name-from-path path-only))
 
 ;; -----------------------------------------------------------------------------
@@ -95,11 +94,7 @@
 (define (compress-and-anonymize path)
   (define anon-filename (anonymize-path path))
   (define mod-seconds (file-or-directory-modify-seconds path))
-  (call-with-output-string
-    (lambda (out-port)
-      (call-with-input-file path
-        (lambda (in-port)
-          (gzip-through-ports in-port out-port anon-filename mod-seconds))))))
+  (format "~a	~a	~s" anon-filename mod-seconds (file->string path)))
 
 (define (anonymize-path path)
   (let* ((str (if (path? path) (path->string path) path))


### PR DESCRIPTION
Don't compress files for the check-ex-spec logs. Save the file as a string.

The old design mixes bytes and strings in a terrible way:

1. gzip is a bytes format ... we need to store exactly those bytes to get
   a meaningful result out
2. converting bytes to a string in Racket is a silently lossy transformation
   ... both `string->bytes/utf-8` and `with-output-to-string` generate error
   characters when they find a byte that does not fit UTF-8

We could push bytes to SQL / Postgres, but there may be a similar problem
with their TEXT and MEDIUMTEXT datatypes ... and we surely don't want to
change schemas.