### PR TITLE
Java error2

### DIFF
--- a/forge/kodkod-cli/server/kkcli-reader.rkt
+++ b/forge/kodkod-cli/server/kkcli-reader.rkt
@@ -13,7 +13,8 @@
   ; don't use format-datums, because it's awful with quotes.
   (define src-datums0 (formatem src-lines))
   (define src-datums (append '((require "server.rkt" "kks.rkt" "server-common.rkt")
-                               (define kks (new server% 
+                               (define kks (new server%
+                                                [name "Kodkod"]
                                                 [initializer (thunk (kodkod-initializer #f))]))
                                (send kks initialize)
                                (define stdin (send kks stdin))

--- a/forge/kodkod-cli/server/kks.rkt
+++ b/forge/kodkod-cli/server/kks.rkt
@@ -14,11 +14,14 @@
 (require "server.rkt"
          "server-common.rkt")
 
+(define server-name "Kodkod")
+
 (provide start-server) ; stdin stdout)
 (define (start-server)
   (when (>= (get-verbosity) VERBOSITY_HIGH)
-    (displayln "Starting kodkod server."))
+    (printf "Starting ~a server.~n" server-name))
   (define kks (new server%
+                   [name server-name]
                    [initializer (thunk (kodkod-initializer #f))]))
   (send kks initialize)
   (define stdin-val (send kks stdin))
@@ -171,8 +174,8 @@
     [(list (== 'no-more-instances))
      (cons 'no-more-instances #f)]
     [(== eof)
-     (port-echo err-port (current-error-port) #:title "Kodkod")
-     (error "Kodkod CLI shut down unexpectedly while running!")]
+     (port-echo err-port (current-error-port) #:title server-name)
+     (error (format "~a CLI shut down unexpectedly while running!" server-name))]
     [other (error 'read-solution "Unrecognized solver output: ~a" other)]))
 
 (define (read-evaluation port err-port)
@@ -187,5 +190,5 @@
     [(list (== 'evaluated) (== ':formula) val)
      (cons 'formula (equal? val 'true))]
     [(== eof)
-     (port-echo err-port (current-error-port) #:title "Kodkod")
-     (error "Kodkod CLI shut down unexpectedly while evaluating!")]))
+     (port-echo err-port (current-error-port) #:title server-name)
+     (error (format "~a CLI shut down unexpectedly while evaluating!" server-name))]))

--- a/forge/kodkod-cli/server/server.rkt
+++ b/forge/kodkod-cli/server/server.rkt
@@ -25,9 +25,9 @@
 
     (if incremental?
         (subprocess #f #f #f
-                    java "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
+                    java "-cp" cp "--add-opens" "java.base/java.lang=ALL-UNNAMED" (string-append "-Djava.library.path=" (path->string kodkod/jar))
                     "kodkod.cli.KodkodServer" "-incremental" "-error-out" error-out)
         (subprocess #f #f #f
-                    java "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
+                    java "-cp" cp "--add-opens" "java.base/java.lang=ALL-UNNAMED" (string-append "-Djava.library.path=" (path->string kodkod/jar))
                     "kodkod.cli.KodkodServer" "-stepper" "-error-out" error-out))))
 

--- a/forge/pardinus-cli/server/kkcli-reader.rkt
+++ b/forge/pardinus-cli/server/kkcli-reader.rkt
@@ -13,7 +13,8 @@
   ; don't use format-datums, because it's awful with quotes.
   (define src-datums0 (formatem src-lines))
   (define src-datums (append '((require "server.rkt" "kks.rkt" "server-common.rkt")
-                               (define kks (new server% 
+                               (define kks (new server%
+                                                [name "Pardinus"]
                                                 [initializer (thunk (pardinus-initializer #f))]))
                                (send kks initialize)
                                (define stdin (send kks stdin))

--- a/forge/pardinus-cli/server/kks.rkt
+++ b/forge/pardinus-cli/server/kks.rkt
@@ -14,11 +14,14 @@
 (require "server.rkt"
          "server-common.rkt")
 
+(define server-name "Pardinus")
+
 (provide start-server) ; stdin stdout)
 (define (start-server [solver-type 'stepper] [solver-subtype 'default])
   (when (>= (get-verbosity) VERBOSITY_HIGH)
-    (displayln "Starting pardinus server."))
+    (printf "Starting ~a server.~n" server-name))
   (define kks (new server%
+                   [name server-name]
                    [initializer (thunk (pardinus-initializer solver-type solver-subtype))]))
   (send kks initialize)
   (define stdin-val (send kks stdin))
@@ -189,8 +192,8 @@
     [(list (== 'no-more-instances))
      (list 'no-more-instances #f '())]
     [(== eof)
-     (port-echo err-port (current-error-port) #:title "Pardinus")
-     (error "Pardinus CLI shut down unexpectedly while running!")]
+     (port-echo err-port (current-error-port) #:title server-name)
+     (error (format "~a CLI shut down unexpectedly while running!" server-name))]
     [other (error 'read-solution "Unrecognized solver output: ~a" other)]))
 
 (define (read-evaluation port err-port)
@@ -207,5 +210,5 @@
     [(list (== 'unsat))
      (error "Current engine ran out of instances; evaluator is untrustworthy.")]
     [(== eof)
-     (port-echo err-port (current-error-port) #:title "Pardinus")
-     (error "Pardinus CLI shut down unexpectedly while evaluating!")]))
+     (port-echo err-port (current-error-port) #:title server-name)
+     (error (format "~a CLI shut down unexpectedly while evaluating!" server-name))]))

--- a/forge/pardinus-cli/server/server.rkt
+++ b/forge/pardinus-cli/server/server.rkt
@@ -38,10 +38,13 @@
       (printf "  Subprocess invocation information: ~a~n"
               (list java "-cp" cp "kodkod.cli.KodkodServer" (format "-~a" solver-type) solver-subtype-str "-error-out" error-out)))
 
-    (subprocess #f #f #f
-                java "-cp" cp "--add-opens" "java.base/java.lang=ALL-UNNAMED" lib-path
-                "kodkod.cli.KodkodServer" 
-                (format "-~a" solver-type)
-                solver-subtype-str 
-                "-error-out" error-out)))
+    (apply
+      subprocess #f #f #f java
+      (append
+        (if (java>=1.9? java) (list "--add-opens" "java.base/java.lang=ALL-UNNAMED") '())
+        (list "-cp" cp
+              lib-path
+              "kodkod.cli.KodkodServer"
+              (format "-~a" solver-type) solver-subtype-str
+              "-error-out" error-out)))))
 

--- a/forge/pardinus-cli/server/server.rkt
+++ b/forge/pardinus-cli/server/server.rkt
@@ -39,7 +39,7 @@
               (list java "-cp" cp "kodkod.cli.KodkodServer" (format "-~a" solver-type) solver-subtype-str "-error-out" error-out)))
 
     (subprocess #f #f #f
-                java "-cp" cp lib-path
+                java "-cp" cp "--add-opens" "java.base/java.lang=ALL-UNNAMED" lib-path
                 "kodkod.cli.KodkodServer" 
                 (format "-~a" solver-type)
                 solver-subtype-str 

--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -300,7 +300,7 @@
   ; Print solve
   (define (get-next-model [mode ""])
     (unless (is-running?)
-      (raise "KodKod server is not running."))
+      (raise-user-error "KodKod server is not running."))
     (pardinus-print (pardinus:solve mode))
     (define result (translate-from-kodkod-cli
                     'run 

--- a/forge/shared.rkt
+++ b/forge/shared.rkt
@@ -2,12 +2,14 @@
 
 (require racket/runtime-path racket/file)
 (require (only-in racket/draw color%)
-         (only-in racket make-object))
+         (only-in racket make-object)
+         (only-in racket/system system*)
+         (only-in racket/port call-with-output-string))
 (require racket/stream)
 
 (provide get-verbosity set-verbosity VERBOSITY_LOW VERBOSITY_HIGH VERBOSITY_DEBUG VERBOSITY_LASTCHECK)
 (provide forge-version instance-diff CORE-HIGHLIGHT-COLOR)
-(provide stream-map/once port-echo)
+(provide stream-map/once port-echo java>=1.9?)
 
 (define CORE-HIGHLIGHT-COLOR (make-object color% 230 150 150))
 
@@ -61,4 +63,30 @@
     (fprintf out-port "~a logs:~n" title))
   (for ([ln (in-lines in-port)])
     (displayln ln out-port)))
+
+(define (java>=1.9? java-exe)
+  (define version-str (shell java-exe "-version"))
+  (define major-nums
+    (let ([m (or
+               (regexp-match #rx"java version \"([0-9+]).([0-9+])." version-str)
+               (raise-arguments-error 'forge/shared
+                                      "Error checking Java version"
+                                      "java exe" java-exe
+                                      "version string" version-str))])
+      (map string->number (cdr m))))
+  (and (<= 1 (car major-nums))
+       (<= 9 (cadr major-nums))))
+
+(define (shell exe pre-cmd)
+  (define success? (box #f))
+  (define cmd* (if (string? pre-cmd) (list pre-cmd) pre-cmd))
+  (define str
+    (call-with-output-string
+      (lambda (p)
+        (parameterize ([current-output-port p]
+                       [current-error-port p]) ;; ARGH JAVA
+          (set-box! success? (apply system* exe cmd*))))))
+  (if (unbox success?)
+    str
+    (raise-user-error 'shell "failed to apply '~a' to arguments '~a'" exe cmd*)))
 

--- a/forge/shared.rkt
+++ b/forge/shared.rkt
@@ -68,12 +68,12 @@
   (define version-str (shell java-exe "-version"))
   (define major-nums
     (let ([m (or
-               (regexp-match #rx"java version \"([0-9+]).([0-9+])." version-str)
+               (regexp-match #rx"(java|openjdk) version \"([0-9+]).([0-9+])." version-str)
                (raise-arguments-error 'forge/shared
                                       "Error checking Java version"
                                       "java exe" java-exe
                                       "version string" version-str))])
-      (map string->number (cdr m))))
+      (map string->number (cddr m))))
   (and (<= 1 (car major-nums))
        (<= 9 (cadr major-nums))))
 

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -510,7 +510,7 @@ Returns whether the given run resulted in sat or unsat, respectively.
 
 (define (assert-is-running run)
   (unless (is-running? run)
-    (raise "KodKod server is not running.")))
+    (raise-user-error "KodKod server is not running.")))
 
 (require (for-syntax syntax/srcloc)) ; for these macros
 


### PR DESCRIPTION
1. Print subprocess output + errors on failure
2. Check if user has Java 1.9 or later. If so, use the `--add-opens` option (thanks @emmiehe)