### PR TITLE
Re-add support for `lone` sigs

### DIFF
--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -374,7 +374,7 @@
 ; Given a Run-spec, assigns names to each sig, assigns minimum and maximum 
 ; sets of atoms for each, and find the total number of atoms needed (including ints).
 (define (get-sig-bounds run-spec raise-run-error)
-  (define pbindings (Bound-pbindings (Run-spec-bounds run-spec)))
+  (define pbindings (Bound-pbindings (Run-spec-bounds run-spec)))  
   (define (get-bound-lower sig)
     (define pbinding (hash-ref pbindings sig #f))
     (@and pbinding ;; !!!
@@ -503,12 +503,12 @@
   (define sig-atoms (list))
   (for ([root (get-top-level-sigs run-spec)]
         #:unless (equal? (Sig-name root) 'Int))
-    (if (get-bound-upper root)
+    (if (get-bound-upper root) ; Do we already have a tuple-based upper bound?
         (let ()
           (fill-lower-by-bound root)
-          (fill-upper-with-bound root))
+          (fill-upper-with-bound root))           
         (let ()
-          (fill-lower-by-scope root)
+          (fill-lower-by-scope root) ; No tuple-based bound yet; extrapolate from scope
           (define lower-size (length (hash-ref lower-bounds root)))
           (define upper-size
             (or (get-scope-upper root)
@@ -517,6 +517,7 @@
 
           (define shared (generate-names root (@- upper-size lower-size)))
           (fill-upper-no-bound root shared)))
+    ;(printf "filling bounds at ~a; upper = ~a; lower = ~a~n" root upper-bounds lower-bounds)
     (set! sig-atoms (append sig-atoms (hash-ref upper-bounds root))))
 
   ; Set the bounds for the Int built-in sig

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -66,6 +66,7 @@
 (struct Sig node/expr/relation (
   name ; symbol?
   one ; boolean?
+  lone ; boolean?
   abstract ; boolean?
   extends ; (or/c Sig? #f)
   ) #:transparent
@@ -183,7 +184,7 @@
 ;;;;;;    Constants    ;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define-syntax Int (lambda (stx) (syntax-case stx ()
-  [val (identifier? (syntax val)) (quasisyntax/loc stx (Sig (nodeinfo #,(build-source-location stx) 'checklangplaceholder) 1 "Int" (thunk '("Int")) "univ" #f 'Int #f #f #f))])))
+  [val (identifier? (syntax val)) (quasisyntax/loc stx (Sig (nodeinfo #,(build-source-location stx) 'checklangplaceholder) 1 "Int" (thunk '("Int")) "univ" #f 'Int #f #f #f #f))])))
 (define-syntax succ (lambda (stx) (syntax-case stx ()
   [val (identifier? (syntax val)) (quasisyntax/loc stx (Relation (nodeinfo #,(build-source-location stx) 'checklangplaceholder) 2 "succ" (thunk '("Int" "Int")) "Int" #f 'succ (list (thunk Int) (thunk Int)) #f))])))
 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -292,12 +292,14 @@
           (~alt (~optional (~seq #:in super-sig:expr)) ;check if this supports "sig A in B + C + D ..."
                 (~optional (~seq #:extends parent:expr))
                 (~optional (~or (~seq (~and #:one one-kw))
+                                (~seq (~and #:lone lone-kw))
                                 (~seq (~and #:abstract abstract-kw))))
                 (~optional (~seq #:is-var is-var) #:defaults ([is-var #'#f]))) ...)
      (quasisyntax/loc stx
        (begin
          (define true-name 'name)
          (define true-one (~? (~@ (or #t 'one-kw)) (~@ #f)))
+         (define true-lone (~? (~@ (or #t 'lone-kw)) (~@ #f)))
          (define true-abstract (~? (~@ (or #t 'abstract-kw)) (~@ #f)))
          (define true-parent (~? (get-sig curr-state parent)
                                  #f))
@@ -311,6 +313,7 @@
            (if is-var #t #f))
          (define name (make-sig true-name
                                 #:one true-one
+                                #:lone true-lone
                                 #:abstract true-abstract
                                 #:is-var isv
                                 ;let #:in default to #f until it is implemented

--- a/forge/tests/forge/sigs/loneSigs.rkt
+++ b/forge/tests/forge/sigs/loneSigs.rkt
@@ -1,0 +1,27 @@
+#lang forge
+
+option verbose 0
+
+lone sig MaybeObject {}
+
+sig Stuff {}
+
+test expect {
+    loneSigEnforced : { one MaybeObject or no MaybeObject } is theorem
+    loneSigPermissive : { no MaybeObject } is sat
+    loneSigPermissive : { one MaybeObject } is sat    
+    loneSigIsntPersistent : { #Stuff = 2 } is sat
+}
+
+
+sig Thing {}
+lone sig SpecialPossibility extends Thing {}
+sig UnspecialThing extends Thing {}
+
+test expect loneExtending {
+    loneExtendActuallyExtends : { SpecialPossibility in Thing } is theorem
+    loneExtenderSigEnforced : { one SpecialPossibility or no SpecialPossibility } is theorem
+    loneExtenderSigPermissive : { no SpecialPossibility } is sat
+    loneExtenderSigPermissive : { one SpecialPossibility } is sat    
+    loneExtendDoesntSpread : { #UnspecialThing = 2 } is sat
+}


### PR DESCRIPTION
The Sig struct now has both a #:one and #:lone option, with the #:one taking precedence. Trying to provide both (only possible in core or functional, not surface) will result in an error. 

This approach is mildly kludgey (ideally it'd be some sort of multiplicity keyword arg) but potential for interaction seems low.
