### PR TITLE
log2022: register logs early, log parse errors

### DIFF
--- a/forge/bsl/lang/reader.rkt
+++ b/forge/bsl/lang/reader.rkt
@@ -60,11 +60,12 @@
 (define (read-syntax path port)
   (define this-lang 'forge/bsl)
   (define-values (logging-on? project email) (log:setup this-lang port path))
-  (define parse-tree (parse path (make-tokenizer port)))
-  (define ints-coerced (coerce-ints-to-atoms parse-tree))
   (define compile-time (current-seconds))
   (when logging-on?
+    (uncaught-exception-handler (log:error-handler logging-on? compile-time (uncaught-exception-handler)))
     (log:register-run compile-time project this-lang email path))
+  (define parse-tree (parse path (make-tokenizer port)))
+  (define ints-coerced (coerce-ints-to-atoms parse-tree))
   (define final `((provide (except-out (all-defined-out) ; So other programs can require it
                                        forge:n))
 

--- a/forge/check-ex-spec/lang/reader.rkt
+++ b/forge/check-ex-spec/lang/reader.rkt
@@ -30,6 +30,10 @@
   (define-values (logging-on? assignment-name user) (log:setup this-lang port path))
   (unless (string? assignment-name)
     (raise (format "Argument error: expected string after #lang ~a; received ~a.~n" this-lang assignment-name)))
+  (define compile-time (current-seconds))
+  (when logging-on?
+    (uncaught-exception-handler (log:error-handler logging-on? compile-time (uncaught-exception-handler)))
+    (log:register-run compile-time assignment-name this-lang user path))
 
   (define assignment-info (check-ex-spec:get-info assignment-name))
   (define wheats (map (curry format "~a.rkt" ) (hash-ref assignment-info 'wheats)))
@@ -42,10 +46,6 @@
   (define not-tests (cdr (syntax->list (filter-commands ints-coerced '(InstDecl OptionDecl PredDecl FunDecl)))))
   (define safe-not-tests (filter-names not-tests provided))
   (define just-tests (cdr (syntax->list (filter-commands ints-coerced '(ExampleDecl TestExpectDecl)))))
-
-  (define compile-time (current-seconds))
-  (when logging-on?
-    (log:register-run compile-time assignment-name this-lang user path))
 
   (define module-datum `(module forge/check-ex-spec-mod forge/check-ex-spec/lang/expander
                           (require forge/check-ex-spec/library)

--- a/forge/core/lang/reader.rkt
+++ b/forge/core/lang/reader.rkt
@@ -7,12 +7,13 @@
 (define (read-syntax path port)
   (define this-lang 'forge/core)
   (define-values (logging-on? project email) (log:setup this-lang port path))
+  (define compile-time (current-seconds))
+  (when logging-on?
+    (uncaught-exception-handler (log:error-handler logging-on? compile-time (uncaught-exception-handler)))
+    (log:register-run compile-time project this-lang email path))
 
   ; Using "read" will not bring in syntax location info
   (define parse-tree (port->list (lambda (x) (@read-syntax path x)) port))
-  (define compile-time (current-seconds))
-  (when logging-on?
-    (log:register-run compile-time project this-lang email path))
   (define module-datum `(module forge-core-mod racket
                           (require forge/choose-lang-specific)
                           (require forge/lang/lang-specific-checks) ; TODO: can this be relative?

--- a/forge/lang/reader.rkt
+++ b/forge/lang/reader.rkt
@@ -60,11 +60,12 @@
 (define (read-syntax path port)
   (define this-lang 'forge)
   (define-values (logging-on? project email) (log:setup this-lang port path))
-  (define parse-tree (parse path (make-tokenizer port)))
-  (define ints-coerced (coerce-ints-to-atoms parse-tree))
   (define compile-time (current-seconds))
   (when logging-on?
+    (uncaught-exception-handler (log:error-handler logging-on? compile-time (uncaught-exception-handler)))
     (log:register-run compile-time project this-lang email path))
+  (define parse-tree (parse path (make-tokenizer port)))
+  (define ints-coerced (coerce-ints-to-atoms parse-tree))
   (define final `((provide (except-out (all-defined-out) ; So other programs can require it
                                        forge:n))
 


### PR DESCRIPTION
To log parse errors: Reorder some definitions & set up an error-handler when logging is on.