### PR TITLE
[minor] Regular update

### DIFF
--- a/forge/bsl/lang/bsl-lang-specific-checks.rkt
+++ b/forge/bsl/lang/bsl-lang-specific-checks.rkt
@@ -13,7 +13,7 @@
 
 (define (raise-bsl-relational-error rel-str node loc [optional-str #f])  
   (raise-bsl-error 
-          (format "Froglet didn't recognize the ~a operator~a"
+          (format "Froglet didn't recognize the ~a operator ~a"
             rel-str
             (if optional-str (format "; ~a" optional-str) "")) 
           node loc))
@@ -178,7 +178,7 @@
 (define (check-node-expr-op-~ expr-node)
   (when (eq? (nodeinfo-lang (node-info expr-node)) 'bsl)
     (define loc (nodeinfo-loc (node-info expr-node)))
-    (raise-bsl-relational-error "~" expr-node loc)))
+    (raise-bsl-relational-error "~~" expr-node loc)))
 
 (define (check-node-expr-op-sing expr-node)
   (void))
@@ -294,7 +294,7 @@
 (define (check-args-node-expr-op-~ expr-args info)
   (when (eq? (nodeinfo-lang info) 'bsl)
       (define loc (nodeinfo-loc info))
-      (raise-bsl-relational-error-expr-args "~" expr-args loc)))
+      (raise-bsl-relational-error-expr-args "~~" expr-args loc)))
 
 ; TODO: add a global field-decl check outside bsl
 (define (bsl-field-decl-func true-breaker)

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -1277,8 +1277,8 @@
     [(? node/expr/op/~?)
      (let ([child (deparse-expr (first (node/expr/op-children expr)) PRIORITY-TILDE)])
         (if (@< PRIORITY-TILDE parent-priority)
-            (format "(~a ~a)" '~ child)
-            (format "~a ~a" '~ child)))]
+            (format "(~a ~a)" '~~ child)
+            (format "~a ~a" '~~ child)))]
     [(? node/expr/op/sing?)
      (let ([child (deparse-int (first (node/expr/op-children expr)) 0)])
             (format "sing[~a]" child))]))

--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -160,9 +160,10 @@
   ; Note that target mode is passed separately, nearer to the (solve) invocation
   (define bitwidth (get-bitwidth run-spec)) 
   (pardinus-print
-    (pardinus:configure (format ":bitwidth ~a :solver ~a :max-solutions 1 :verbosity 7 :skolem-depth ~a :sb ~a :core-gran ~a :core-minimization ~a :log-trans ~a ~a ~a"
+    (pardinus:configure (format ":bitwidth ~a :solver ~a :max-solutions 1 :verbosity ~a :skolem-depth ~a :sb ~a :core-gran ~a :core-minimization ~a :log-trans ~a ~a ~a"
                                bitwidth 
                                solverspec
+                               (get-option run-spec 'engine_verbosity) ; see the Wiki for levels
                                (get-option run-spec 'skolem_depth)
                                (get-option run-spec 'sb) 
                                (get-option run-spec 'coregranularity)

--- a/forge/server/forgeserver.rkt
+++ b/forge/server/forgeserver.rkt
@@ -150,7 +150,8 @@
                   (send-to-sterling "pong" #:connection connection)]
                  [else (handle-json connection m)])
            (loop))))
-     #:port 0 #:confirmation-channel chan))
+     ; default #:port 0 will assign an ephemeral port
+     #:port (get-option the-run 'sterling_port) #:confirmation-channel chan))
 
   (define port (async-channel-get chan))
   (cond [(string? port)
@@ -159,7 +160,9 @@
          (void)]
         [else
          (send-url/file sterling-path #f #:query (number->string port))
-         (printf "Sterling running. Hit enter to stop service.\n")         
+         (printf "Sterling running. Hit enter to stop service.\n")
+         (when (> (get-verbosity) VERBOSITY_LOW)
+           (printf "Using port: ~a~n" (number->string port)))
          (flush-output)
          (void (read-char))
          (stop-service)]))

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -108,7 +108,10 @@
   ) #:transparent)
 
 ; If adding new option fields, remember to update all of:
-;  --default value -- state-set-option and -- get-option
+;  -- DEFAULT_OPTIONS
+;  -- symbol->proc
+;  -- option-types
+;  -- state-set-option (in sigs.rkt)
 (struct/contract Options (
   [eval-language symbol?]
   [solver symbol?]
@@ -124,6 +127,7 @@
   [skolem_depth nonnegative-integer?]
   [local_necessity symbol?]
   [run_sterling symbol?]
+  [sterling_port nonnegative-integer?]
   ) #:transparent)
 
 (struct/contract State (
@@ -177,7 +181,7 @@
 
 (define DEFAULT-BITWIDTH 4)
 (define DEFAULT-SIG-SCOPE (Range 0 4))
-(define DEFAULT-OPTIONS (Options 'surface 'SAT4J 'pardinus 20 0 0 1 5 'default 'close-noretarget 'fast 0 'off 'on))
+(define DEFAULT-OPTIONS (Options 'surface 'SAT4J 'pardinus 20 0 0 1 5 'default 'close-noretarget 'fast 0 'off 'on 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;    Constants    ;;;;;;;
@@ -211,7 +215,8 @@
         'core_minimization Options-core_minimization
         'skolem_depth Options-skolem_depth
         'local_necessity Options-local_necessity
-        'run_sterling Options-run_sterling))
+        'run_sterling Options-run_sterling
+        'sterling_port Options-sterling_port))
 
 (define option-types
   (hash 'eval-language symbol?
@@ -228,7 +233,8 @@
         'core_minimization symbol?
         'skolem_depth exact-integer?
         'local_necessity symbol?
-        'run_sterling symbol?))
+        'run_sterling symbol?
+        'sterling_port exact-nonnegative-integer?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;  Initial State  ;;;;;;;

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -123,11 +123,12 @@
   [max_tracelength nonnegative-integer?]
   [problem_type symbol?]
   [target_mode symbol?]
-  [core_minimization symbol?]
-  [skolem_depth nonnegative-integer?]
+  [core_minimization symbol?]  
+  [skolem_depth integer?] ; allow -1 (disable Skolemization entirely)
   [local_necessity symbol?]
   [run_sterling symbol?]
   [sterling_port nonnegative-integer?]
+  [engine_verbosity nonnegative-integer?]
   ) #:transparent)
 
 (struct/contract State (
@@ -181,7 +182,7 @@
 
 (define DEFAULT-BITWIDTH 4)
 (define DEFAULT-SIG-SCOPE (Range 0 4))
-(define DEFAULT-OPTIONS (Options 'surface 'SAT4J 'pardinus 20 0 0 1 5 'default 'close-noretarget 'fast 0 'off 'on 0))
+(define DEFAULT-OPTIONS (Options 'surface 'SAT4J 'pardinus 20 0 0 1 5 'default 'close-noretarget 'fast 0 'off 'on 0 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;    Constants    ;;;;;;;
@@ -216,7 +217,8 @@
         'skolem_depth Options-skolem_depth
         'local_necessity Options-local_necessity
         'run_sterling Options-run_sterling
-        'sterling_port Options-sterling_port))
+        'sterling_port Options-sterling_port
+        'engine_verbosity Options-engine_verbosity))
 
 (define option-types
   (hash 'eval-language symbol?
@@ -234,7 +236,8 @@
         'skolem_depth exact-integer?
         'local_necessity symbol?
         'run_sterling symbol?
-        'sterling_port exact-nonnegative-integer?))
+        'sterling_port exact-nonnegative-integer?
+        'engine_verbosity exact-nonnegative-integer?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;  Initial State  ;;;;;;;

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -533,7 +533,7 @@
              (when (@> (get-verbosity) 0)
                (printf "Unexpected result found, with statistics and metadata:~n")
                (pretty-print first-instance))
-             (raise (format "Failed test ~a. Expected ~a, got ~a.~a"
+             (raise-user-error (format "Failed test ~a. Expected ~a, got ~a.~a"
                             'name 'expected (if (Sat? first-instance) 'sat 'unsat)
                             (if (Sat? first-instance)
                                 (format " Found instance ~a" first-instance)
@@ -549,7 +549,7 @@
              (when (@> (get-verbosity) 0)
                (printf "Instance found, with statistics and metadata:~n")
                (pretty-print first-instance))
-             (raise (format "Theorem ~a failed. Found instance:~n~a"
+             (raise-user-error (format "Theorem ~a failed. Found instance:~n~a"
                             'name first-instance)))
            (close-run name)]
 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -530,6 +530,8 @@
            (run name args ...)
            (define first-instance (tree:get-value (Run-result name)))
            (unless (equal? (if (Sat? first-instance) 'sat 'unsat) 'expected)
+             (printf "Instance found, with statistics and metadata:~n")
+             (pretty-print first-instance)
              (raise (format "Failed test ~a. Expected ~a, got ~a.~a"
                             'name 'expected (if (Sat? first-instance) 'sat 'unsat)
                             (if (Sat? first-instance)
@@ -543,6 +545,8 @@
            (check name args ...)
            (define first-instance (tree:get-value (Run-result name)))
            (when (Sat? first-instance)
+             (printf "Instance found, with statistics and metadata:~n")
+             (pretty-print first-instance)             
              (raise (format "Theorem ~a failed. Found instance:~n~a"
                             'name first-instance)))
            (close-run name)]

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -1034,7 +1034,7 @@ Now with functional forge, do-bind is used instead
   (unless (equal? 1 (node/expr-arity b)) (raise-user-error (format "Second argument \"~a\" to reachable is not a singleton at loc ~a" (deparse b) (srcloc->string loc))))
   (in/info (nodeinfo loc 'checklangNoCheck) 
            a 
-           (join/info (nodeinfo loc 'bsl) 
+           (join/info (nodeinfo loc (get-check-lang)) 
                       b 
                       (^/info (nodeinfo loc 'checklangNoCheck) (union-relations loc r)))))
 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -251,7 +251,10 @@
                     [skolem_depth value])]
       [(equal? option 'run_sterling)
        (struct-copy Options options
-                    [run_sterling value])]))
+                    [run_sterling value])]
+      [(equal? option 'sterling_port)
+       (struct-copy Options options
+                    [sterling_port value])]))
 
   (struct-copy State state
                [options new-options]))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -254,13 +254,13 @@
                     [run_sterling value])]
       [(equal? option 'sterling_port)
        (struct-copy Options options
-                    [sterling_port value])]))
+                    [sterling_port value])]
+      [(equal? option 'engine_verbosity)
+       (struct-copy Options options
+                    [engine_verbosity value])]))
 
   (struct-copy State state
                [options new-options]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -530,8 +530,9 @@
            (run name args ...)
            (define first-instance (tree:get-value (Run-result name)))
            (unless (equal? (if (Sat? first-instance) 'sat 'unsat) 'expected)
-             (printf "Instance found, with statistics and metadata:~n")
-             (pretty-print first-instance)
+             (when (@> (get-verbosity) 0)
+               (printf "Unexpected result found, with statistics and metadata:~n")
+               (pretty-print first-instance))
              (raise (format "Failed test ~a. Expected ~a, got ~a.~a"
                             'name 'expected (if (Sat? first-instance) 'sat 'unsat)
                             (if (Sat? first-instance)
@@ -545,8 +546,9 @@
            (check name args ...)
            (define first-instance (tree:get-value (Run-result name)))
            (when (Sat? first-instance)
-             (printf "Instance found, with statistics and metadata:~n")
-             (pretty-print first-instance)             
+             (when (@> (get-verbosity) 0)
+               (printf "Instance found, with statistics and metadata:~n")
+               (pretty-print first-instance))
              (raise (format "Theorem ~a failed. Found instance:~n~a"
                             'name first-instance)))
            (close-run name)]

--- a/forge/tests/error/arrow-ast.frg
+++ b/forge/tests/error/arrow-ast.frg
@@ -6,8 +6,10 @@ sig Node {
 
 one sig A, B extends Node {}
 
-pred setSingle {
-    A.next = Node
+pred arrow {
+    A->next in next
 }
 
-test expect {{setSingle} is sat}
+test expect {
+    {arrow} is sat
+}

--- a/forge/tests/error/arrow.frg
+++ b/forge/tests/error/arrow.frg
@@ -10,4 +10,6 @@ pred arrow {
     A->B in next
 }
 
-run {arrow}
+test expect {
+    {arrow} is sat
+}

--- a/forge/tests/error/failed_sat.frg
+++ b/forge/tests/error/failed_sat.frg
@@ -1,0 +1,8 @@
+#lang forge
+option verbose 0
+
+sig Cell {}
+
+test expect {    
+    foo: {Cell != Cell} is sat
+}

--- a/forge/tests/error/failed_theorem.frg
+++ b/forge/tests/error/failed_theorem.frg
@@ -1,0 +1,8 @@
+#lang forge
+option verbose 0
+
+sig Cell {}
+
+test expect {    
+    foo: {Cell != Cell} is theorem    
+}

--- a/forge/tests/error/failed_unsat.frg
+++ b/forge/tests/error/failed_unsat.frg
@@ -1,0 +1,8 @@
+#lang forge
+option verbose 0
+
+sig Cell {}
+
+test expect {    
+    foo: {Cell = Cell} is unsat
+}

--- a/forge/tests/error/int-minus.frg
+++ b/forge/tests/error/int-minus.frg
@@ -11,4 +11,6 @@ pred intMinus {
    some  (A.val - B.val)
 }
 
-run {intMinus}
+test expect{
+    {intMinus} is sat
+}

--- a/forge/tests/error/intersect-ast.frg
+++ b/forge/tests/error/intersect-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some (A & next)
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/join-right.frg
+++ b/forge/tests/error/join-right.frg
@@ -10,4 +10,6 @@ pred joinRight {
     some next.B
 }
 
-run {joinRight}
+test expect{
+     {joinRight} is sat
+}

--- a/forge/tests/error/join-right2.frg
+++ b/forge/tests/error/join-right2.frg
@@ -11,4 +11,6 @@ pred joinRight {
     some A.field.Node
 }
 
-run {joinRight}
+test expect{
+     {joinRight} is sat
+}

--- a/forge/tests/error/join-right3.frg
+++ b/forge/tests/error/join-right3.frg
@@ -10,5 +10,5 @@ one sig A, B extends Node {}
 pred joinRight {
     some A.field.A
 }
-
-run {joinRight}
+ 
+test expect {{joinRight} is sat}

--- a/forge/tests/error/join-right4.frg
+++ b/forge/tests/error/join-right4.frg
@@ -13,4 +13,6 @@ pred fieldsEqual {
     some s1, s2: Student| s1.transcript.Grade = s2.transcript.Grade
 }
 
-run {fieldsEqual}
+test expect {
+    {fieldsEqual} is sat
+}

--- a/forge/tests/error/join-right5.frg
+++ b/forge/tests/error/join-right5.frg
@@ -11,4 +11,4 @@ pred rightjoin {
     reachable[A, A.field.Node, next]
 }
 
-run {rightjoin}
+test expect{ {rightjoin} is sat}

--- a/forge/tests/error/join-right6.frg
+++ b/forge/tests/error/join-right6.frg
@@ -11,4 +11,4 @@ pred joinRight {
     some A.(field.A)
 }
 
-run {joinRight}
+test expect {{joinRight} is sat}

--- a/forge/tests/error/join.frg
+++ b/forge/tests/error/join.frg
@@ -10,4 +10,4 @@ pred leftjoin {
     some next.next
 }
 
-run {leftjoin}
+test expect {{leftjoin} is sat}

--- a/forge/tests/error/join2.frg
+++ b/forge/tests/error/join2.frg
@@ -10,4 +10,4 @@ pred leftjoin {
     some A.field
 }
 
-run {leftjoin}
+test expect {{leftjoin} is sat}

--- a/forge/tests/error/join3.frg
+++ b/forge/tests/error/join3.frg
@@ -10,4 +10,4 @@ pred leftjoin {
     some Node.next
 }
 
-run {leftjoin}
+test expect {{leftjoin} is sat}

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -54,8 +54,8 @@
     (list "excluded-extender-value.frg" #rx"not a subset")
     (list "example_impossible.frg" #rx"impossible")
     (list "failed_theorem.frg" #rx"failed.")
-    (list "failed_unsat.frg" #rx"failed.")
-    (list "failed_sat.frg" #rx"failed.")
+    (list "failed_unsat.frg" #rx"Failed test")
+    (list "failed_sat.frg" #rx"Failed test")
   ))
 
 ;; -----------------------------------------------------------------------------

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -53,6 +53,9 @@
     (list "ill_typed_inst_columns_reversed.frg" #rx"age")
     (list "excluded-extender-value.frg" #rx"not a subset")
     (list "example_impossible.frg" #rx"impossible")
+    (list "failed_theorem.frg" #rx"failed.")
+    (list "failed_unsat.frg" #rx"failed.")
+    (list "failed_sat.frg" #rx"failed.")
   ))
 
 ;; -----------------------------------------------------------------------------

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -25,6 +25,13 @@
   (list
     (list "hello.frg" #rx"parsing error")
     (list "arrow.frg" #rx"Direct use of ->")
+    (list "arrow.frg" #rx"Direct use of ->")
+    (list "plus-ast.frg" #rx"recognize")
+    (list "minus-ast.frg" #rx"recognize")
+    (list "intersect-ast.frg" #rx"recognize")
+    (list "transpose-ast.frg" #rx"recognize")
+    (list "star-ast.frg" #rx"recognize")
+    (list "transitive-closure-ast.frg" #rx"recognize")
     (list "join.frg" #rx"singleton")
     (list "join2.frg" #rx"singleton")
     (list "join3.frg" #rx"singleton")

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -30,6 +30,7 @@
     (list "minus-ast.frg" #rx"recognize")
     (list "intersect-ast.frg" #rx"recognize")
     (list "transpose-ast.frg" #rx"recognize")
+    (list "transpose.frg" #rx"recognize")
     (list "star-ast.frg" #rx"recognize")
     (list "transitive-closure-ast.frg" #rx"recognize")
     (list "join.frg" #rx"singleton")

--- a/forge/tests/error/minus-ast.frg
+++ b/forge/tests/error/minus-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some (A - next)
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/plus-ast.frg
+++ b/forge/tests/error/plus-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some (A + next)
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/reachable.frg
+++ b/forge/tests/error/reachable.frg
@@ -12,4 +12,4 @@ pred cycle {
     all n: Node | reachable[n.next, n, field]
 }
 
-run {cycle}
+test expect {{cycle} is sat}

--- a/forge/tests/error/reachable2.frg
+++ b/forge/tests/error/reachable2.frg
@@ -12,4 +12,4 @@ pred cycle {
     all n: Node | reachable[next, n, next]
 }
 
-run {cycle}
+test expect {{cycle} is sat}

--- a/forge/tests/error/set.frg
+++ b/forge/tests/error/set.frg
@@ -10,4 +10,4 @@ pred setcomp {
     some {n : Node | n.next = n}
 }
 
-run {setcomp}
+test expect {{setcomp} is sat}

--- a/forge/tests/error/star-ast.frg
+++ b/forge/tests/error/star-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some *A
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/transitive-closure-ast.frg
+++ b/forge/tests/error/transitive-closure-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some ^A
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/transpose-ast.frg
+++ b/forge/tests/error/transpose-ast.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some ~A
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/error/transpose.frg
+++ b/forge/tests/error/transpose.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+
+sig Node {
+    next: lone Node
+}
+one sig A, B extends Node{}
+
+pred err {
+    some ~next
+}
+
+test expect{
+    {err} is sat
+}

--- a/forge/tests/forge/relations/breakers.rkt
+++ b/forge/tests/forge/relations/breakers.rkt
@@ -1,5 +1,6 @@
 #lang forge
 
+option verbose 0
 -- Additional tests for lone, one, pfunc, func
 sig A, B, C {}
 one sig FrontDesk {


### PR DESCRIPTION
* Some error checking improved in Froglet. If you use Froglet and a formerly-working model now produces an error, it's likely you're using an operator that should be allowed only in full Forge. E.g., using `.` as more than just field access. If unclear, talk to us! 
* Failed tests will now print the counterexample instance or unsat result in full, provided that the verbosity is > 0. 
* Fixed an issue for Windows users that could cause a lockup. The fix doesn't solve the full problem, but many states + quantifiers should no longer predictably cause Forge to block.