### PR TITLE
[minor] Better join errors, fix custom solver contract

### DIFF
--- a/forge/last-checker.rkt
+++ b/forge/last-checker.rkt
@@ -213,8 +213,16 @@
                     (get-children run-or-state signame)))))
            (cond
              [(Sig-abstract the-sig)
-              all-primitive-descendants]
-             [else (cons (string->symbol (string-append (symbol->string signame) "_remainder"))
+             
+             ; TODO: in the future, maybe consider better places to check for empty abstract sig
+             (if (empty? (get-children run-or-state signame))
+                 (raise-user-error (format "The abstract sig ~a is not extended by any children" (symbol->string signame)))
+                 all-primitive-descendants)]
+             [else (cons 
+                        (string->symbol (string-append (symbol->string signame) 
+                            (if (empty? (get-children run-or-state signame))
+                                ""
+                                "_remainder")))
                          all-primitive-descendants)])])))
 
 ; wrap around checkExpression-mult to provide check for multiplicity, 
@@ -419,8 +427,14 @@
                            (when (empty? join-result)
                             (if (eq? (nodeinfo-lang (node-info expr)) 'bsl)
                                 ((hash-ref checker-hash 'empty-join) expr)
-                                (raise-syntax-error #f (format "join always results in an empty relation")
-                                                  (datum->syntax #f expr (build-source-location-syntax (nodeinfo-loc (node-info expr))))))))
+                              (raise-syntax-error #f 
+                                                (format "~n join always results in an empty relation: ~n Left hand side of join \"~a\" must be one of ~a~n Right hand side of join \"~a\" must be one of ~a~n There is no possible join result " 
+                                                          (deparse (first (node/expr/op-children expr)))  
+                                                          (map (lambda (lst) (string-join (map (lambda (c) (symbol->string c)) lst) " -> " #:before-first "(" #:after-last ")")) (car (first child-values)))
+                                                          (deparse (second (node/expr/op-children expr)))
+                                                          (map (lambda (lst) (string-join (map (lambda (c) (symbol->string c)) lst) " -> " #:before-first "(" #:after-last ")")) (car (second child-values)))
+                                                          )
+                                                  (datum->syntax #f (deparse expr) (build-source-location-syntax (nodeinfo-loc (node-info expr))))))))
                            (when (and (not (cdr (first child-values))) (eq? (nodeinfo-lang (node-info expr)) 'bsl))
                                 ((hash-ref checker-hash 'relation-join) expr args))
                            (cons join-result

--- a/forge/last-checker.rkt
+++ b/forge/last-checker.rkt
@@ -428,7 +428,7 @@
                             (if (eq? (nodeinfo-lang (node-info expr)) 'bsl)
                                 ((hash-ref checker-hash 'empty-join) expr)
                               (raise-syntax-error #f 
-                                                (format "~n join always results in an empty relation: ~n Left hand side of join \"~a\" must be one of ~a~n Right hand side of join \"~a\" must be one of ~a~n There is no possible join result " 
+                                                (format "~n join always results in an empty relation: ~n Left argument of join \"~a\" is in ~a~n Right argument of join \"~a\" is in ~a~n There is no possible join result " 
                                                           (deparse (first (node/expr/op-children expr)))  
                                                           (map (lambda (lst) (string-join (map (lambda (c) (symbol->string c)) lst) " -> " #:before-first "(" #:after-last ")")) (car (first child-values)))
                                                           (deparse (second (node/expr/op-children expr)))

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -6,7 +6,7 @@
 (require (prefix-in @ racket) 
          (prefix-in @ racket/set))
 (require racket/contract)
-(require (for-syntax racket/syntax syntax/srcloc))
+(require (for-syntax racket/syntax syntax/srcloc syntax/parse))
 (require (prefix-in tree: "lazy-tree.rkt"))
 (require syntax/srcloc)
 
@@ -585,9 +585,9 @@ Returns whether the given run resulted in sat or unsat, respectively.
                (=>/info info (! a) c))
       (ite/info info a b c)))
 (define-syntax (ifte stx)
-  (syntax-case stx ()
-    [(_ a b c) (quasisyntax/loc stx
-                 (ifte-disambiguator (nodeinfo #,(build-source-location stx) 'checklangplaceholder) a b c))]))
+  (syntax-parse stx 
+    [(_ (~optional (#:lang check-lang) #:defaults ([check-lang #''checklangNoCheck])) a b c) (quasisyntax/loc stx
+                 (ifte-disambiguator (nodeinfo #,(build-source-location stx) check-lang) a b c))]))
 
 (define-syntax (ni stx) (syntax-case stx () 
       [(_ a b) (quasisyntax/loc stx (in/info (nodeinfo #,(build-source-location stx) 'checklangNoCheck) b a))]
@@ -597,10 +597,12 @@ Returns whether the given run resulted in sat or unsat, respectively.
                                             [(_ (#:lang check-lang) a b) (quasisyntax/loc stx 
                                                              (!/info (nodeinfo #,(build-source-location stx) check-lang)
                                                                      (=/info (nodeinfo #,(build-source-location stx) check-lang) a b)))]))
-(define-syntax (!in stx) (syntax-case stx () [(_ a b) (quasisyntax/loc stx  (!/info (nodeinfo #,(build-source-location stx) 'checklangplaceholder)
-                                                              (in/info (nodeinfo #,(build-source-location stx) 'checklangplaceholder) a b)))]))
-(define-syntax (!ni stx) (syntax-case stx () [(_ a b) (quasisyntax/loc stx (!/info (nodeinfo #,(build-source-location stx) 'checklangplaceholder)
-                                                              (in/info (nodeinfo #,(build-source-location stx) 'checklangplaceholder) b a)))]))
+(define-syntax (!in stx) (syntax-parse stx [(_ (~optional (#:lang check-lang) #:defaults ([check-lang #''checklangNoCheck])) a b) 
+                                                    (quasisyntax/loc stx  (!/info (nodeinfo #,(build-source-location stx) check-lang)
+                                                              (in/info (nodeinfo #,(build-source-location stx) check-lang) a b)))]))
+(define-syntax (!ni stx) (syntax-parse stx [(_ (~optional (#:lang check-lang) #:defaults ([check-lang #''checklangNoCheck])) a b) 
+                                                    (quasisyntax/loc stx (!/info (nodeinfo #,(build-source-location stx) check-lang)
+                                                              (in/info (nodeinfo #,(build-source-location stx) check-lang) b a)))]))
 (define-syntax (>= stx) (syntax-case stx () [(_ a b) (quasisyntax/loc stx (||/info (nodeinfo #,(build-source-location stx) 'checklangNoCheck)
                                                               (int>/info (nodeinfo #,(build-source-location stx) 'checklangNoCheck) a b)
                                                               (int=/info (nodeinfo #,(build-source-location stx) 'checklangNoCheck) a b)))]

--- a/forge/tests/error/abstract.frg
+++ b/forge/tests/error/abstract.frg
@@ -1,0 +1,12 @@
+#lang forge
+
+
+one sig A { field: one B}
+abstract sig B{
+   
+}
+
+test expect {
+ 
+    thm1: {some A.field} is sat
+}

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -24,6 +24,7 @@
 (define REGISTRY
   (list
     (list "hello.frg" #rx"parsing error")
+    (list "abstract.frg" #rx"abstract")
     (list "arrow.frg" #rx"Direct use of ->")
     (list "arrow.frg" #rx"Direct use of ->")
     (list "plus-ast.frg" #rx"recognize")

--- a/forge/tests/forge-core/sigs/abstractSigs.rkt
+++ b/forge/tests/forge-core/sigs/abstractSigs.rkt
@@ -16,9 +16,3 @@
       #:preds [(=> (no (+ Extension1 Extension2)) (no Abstract))]
       #:expect theorem)
 
-
-(sig Unextended #:abstract)
-
-(test unextendedCanPopulate 
-      #:preds [(some Unextended)]
-      #:expect sat)

--- a/forge/tests/forge-functional/sigs/abstractSigs.rkt
+++ b/forge/tests/forge-functional/sigs/abstractSigs.rkt
@@ -19,9 +19,3 @@
            #:sigs (list Abstract Extension1 Extension2)
            #:expect 'theorem)
 
-(define Unextended (make-sig 'Unextended #:abstract #t))
-
-(make-test #:name 'unextendedCanPopulate 
-           #:preds (list (some Unextended))
-           #:sigs (list Abstract Extension1 Extension2 Unextended)
-           #:expect 'sat)

--- a/forge/tests/forge/expressions/ifte.frg
+++ b/forge/tests/forge/expressions/ifte.frg
@@ -1,0 +1,11 @@
+#lang forge
+
+sig Node{}
+one sig A, B extends Node{}
+fun conditional: one Node {
+    true => A else B
+}
+
+test expect {
+    {conditional = A} is theorem
+}

--- a/forge/tests/forge/sigs/abstractSigs.rkt
+++ b/forge/tests/forge/sigs/abstractSigs.rkt
@@ -12,9 +12,3 @@ test expect NormalAbstract {
     emptyExtensionsEmptyAbstract : { no (Extension1 + Extension2) and some Abstract } is unsat
 }
 
-
-abstract sig Unextended {}
-
-test expect UnextendedAbstract {
-    unextendedCanPopulate : { some Unextended } is sat
-}


### PR DESCRIPTION
* Fixed an error that would cause custom solver invocation to return a runtime type error. 
* If an abstract sig has no children, an error will now be produced. This is different from Alloy's behavior (treat the sig as non-abstract internally) but better for spotting errors.
* Improved error messages for necessarily-empty join: will now say what Forge believes can go into the two relations in question.