### PR TITLE
Make unique temporary names (on dev this time)

### DIFF
--- a/forge/check-ex-spec/lang/expander.rkt
+++ b/forge/check-ex-spec/lang/expander.rkt
@@ -97,7 +97,7 @@
                         (~optional scope:ScopeClass)
                         (~optional bounds:BoundsClass)
                         (~and expected (~or "sat" "unsat" "theorem")))
-   (with-syntax ([name #'(~? name.name temporary-name)]
+   (with-syntax ([name #`(~? name.name #,(make-temporary-name stx))]
                  [preds (my-expand #'(~? pred.name preds))]
                  [expected (datum->syntax #'expected
                                           (string->symbol (syntax->datum #'expected)))])

--- a/forge/logging/2022/index.js
+++ b/forge/logging/2022/index.js
@@ -6,7 +6,10 @@ const TABLE_ADDR = "34.75.227.215";
 
 const mysql = require("mysql");
 
-function getConnection () {
+const Firestore = require('@google-cloud/firestore');
+const COLLECTION_NAME = 'events';
+
+function getSQLConnection () {
   const options = 
   {
     host: TABLE_ADDR,
@@ -18,13 +21,26 @@ function getConnection () {
   return mysql.createConnection(options);
 }
 
+function getFirestore () {
+  const options =
+  {
+    projectId: PROJECT_ID,
+    timestampsInSnapshots: true
+  };
+  return new Firestore(options);
+}
+
 exports.submit = (req, res) => {
   //console.log("lfs2022x begin");
   //console.log(req.body);
   res.set('Access-Control-Allow-Origin', '*');
-  if (req.method === 'POST') {
-    let conn = getConnection();
-    //console.log("lfs2022x conn ok");
+  if (req.method === 'OPTIONS') {
+    // Send response to OPTIONS requests
+    res.set('Access-Control-Allow-Methods', 'POST');
+    res.set('Access-Control-Allow-Headers', 'Content-Type');
+    res.set('Access-Control-Max-Age', '3600');
+    res.status(204).send('');
+  } else if (req.method === 'POST') {
     let data;
     if (typeof(req.body) === 'string' || req.body instanceof String) {
       try {
@@ -39,32 +55,59 @@ exports.submit = (req, res) => {
     }
     //console.log("lfs2022x data ok")
     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    const timestamp = new Date().getTime();
+    //console.log("lfs2022x conn ok");
+    let conn;
     let post;
     if (data.payload) {
-      post = null;
-    } else {
+      // Examplar data, send to firestore
+      conn = getFirestore();
       post = {
-      ip: ip,
-      ts: data.ts,
-      local_id: data.local_id,
-      student: data.student,
-      lang: data.lang,
-      project: data.project,
-      input: (data.input && data.input.charCodeAt(0) < 130 && data.input.charCodeAt(1) < 130 && data.input.charCodeAt(2) < 130 && data.input.charCodeAt(3) < 130) ? data.input : "",
-      output: data.output
-    }};
-    //console.log("lfs2022x posting")
-    if (post) {
-    conn.query("INSERT INTO " + TABLE_ID + " SET ?", post, function(err, result) {
-      if (err) {
-        console.error(err);
-        return res.status(500).send({error: 'unable to post', err});
-      } else {
-        return res.status(200).send({});
-      }
-    });
+        ip: ip,
+        timestamp: timestamp,
+        app_timestamp: data.time,
+        session: data.session,
+        event: data.event,
+        email: data.email,
+        assignment: data.assignment,
+        payload: data.payload,
+      };
+      return conn.collection(COLLECTION_NAME)
+        .add(post)
+        .then(doc => {
+          return res.status(200).send({});
+        }).catch(err => {
+          console.error(err);
+          return res.status(500).send({ error: 'unable to store', err });
+        });
+    } else if (data.ts) {
+      conn = getSQLConnection();
+      // Forge data, send to SQL
+      post = {
+        ip: ip,
+        ts: data.ts,
+        local_id: data.local_id,
+        student: data.student,
+        lang: data.lang,
+        project: data.project,
+        input: (data.input && data.input.charCodeAt(0) < 130 && data.input.charCodeAt(1) < 130 && data.input.charCodeAt(2) < 130 && data.input.charCodeAt(3) < 130) ? data.input : "",
+        output: data.output
+      };
+      //console.log("lfs2022x posting")
+      conn.query("INSERT INTO " + TABLE_ID + " SET ?", post, function(err, result) {
+        if (err) {
+          console.error(err);
+          conn.end();
+          return res.status(500).send({error: 'unable to post', err});
+        } else {
+          conn.end();
+          return res.status(200).send({});
+        }
+      });
+    } else {
+      conn.end();
+      return res.status(203).send({});
     }
   }
 };
-
 

--- a/forge/logging/2022/package.js
+++ b/forge/logging/2022/package.js
@@ -2,6 +2,7 @@
   "name": "submit",
   "version": "0.0.1",
   "dependencies": {
-    "mysql": "2.18.1"
+    "mysql": "2.18.1",
+    "@google-cloud/firestore": "3.8.6"
   }
 }

--- a/forge/testme/lang/expander.rkt
+++ b/forge/testme/lang/expander.rkt
@@ -97,7 +97,7 @@
                         (~optional scope:ScopeClass)
                         (~optional bounds:BoundsClass)
                         (~and expected (~or "sat" "unsat" "theorem")))
-   (with-syntax ([name #'(~? name.name temporary-name)]
+   (with-syntax ([name #`(~? name.name #,(make-temporary-name stx))]
                  [preds (my-expand #'(~? pred.name preds))]
                  [expected (datum->syntax #'expected
                                           (string->symbol (syntax->datum #'expected)))])


### PR DESCRIPTION
For anonymous tests etc., generate names like `temporary-name1`, `temporary-name2` ... instead of always using `temporary-name`.

(gensym is a cleaner way to implement this, but gensym'd names won't start counting at `1`)

- - - 

#### Example File

If you run this file, it'll fail the second test:
- before this patch, the failure says `Failed test temporary-name`
- after this patch, it says `Failed test temporary-name2`

```
#lang forge

-- begin wheat

sig Atom {
    p: set Atom,
    q: set Atom
}

pred union {
  Atom.(p + q) = Atom.p + Atom.q
}

pred difference {
  Atom.(p - q) = Atom.p - Atom.q
}

pred intersection {
  Atom.(p & q) = Atom.p & Atom.q
}

-- end wheat

test expect {
    {not union} is unsat
}

test expect {
    {not difference} is unsat
}

test expect {
    {not intersection} is unsat
}
```