### PR TITLE
Removing property nesting inside where blocks

### DIFF
--- a/forge/examples/property-where/undirected_tree_properties.rkt
+++ b/forge/examples/property-where/undirected_tree_properties.rkt
@@ -48,12 +48,15 @@ pred isUndirectedTree {
         }
 
 
+        /*
+        //Nesting not currently supported.
         underconstraint reachability of isUndirected
         {
             all m, n : Node | n->m in edges implies m in n.*edges
         }
         where
         {}
+        */
 }
 
 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -80,7 +80,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
 
 PropertyWhereDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK 
 
-@TestConstruct : ExampleDecl | TestExpectDecl | PropertyWhereDecl
+@TestConstruct : ExampleDecl | TestExpectDecl
 
 
 # UnOp : Mult

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -295,8 +295,7 @@
 
   (define-syntax-class TestConstructClass
     (pattern decl:ExampleDeclClass)
-    (pattern decl:TestExpectDeclClass)
-    (pattern decl:PropertyWhereDeclClass))
+    (pattern decl:TestExpectDeclClass))
 
 
   ;; PropertyWhereDecl : PROPERTY-TOK Name OF-TOK Name Block? WHERE-TOK? Block?

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -46,12 +46,16 @@ pred isUndirectedTree {
             edges = `Node0->`Node0
         }
 
+
+        /*
+        //Nesting not currently supported.
         underconstraint reachability of isUndirected
         {
             all m, n : Node | n->m in edges implies m in n.*edges
         }
         where
         {}
+        */
 }
 
 


### PR DESCRIPTION
Preventing nested property/where declarations in where blocks. This pattern is no longer supported:

```
 underconstraint p of q
 {
     <Expr>
 } 
 where {
        underconstraint r of p
        {
            ...
        }
        where
        {}   
}
```

Where blocks must now exclusively contain examples and tests.