### PR TITLE
Optional 'where' blocks for property tests

### DIFF
--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -78,7 +78,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
-PropertyWhereDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK 
+PropertyWhereDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
 
 @TestConstruct : ExampleDecl | TestExpectDecl
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -309,8 +309,7 @@
               prop-expr:BlockClass
               (~optional -scope:ScopeClass)
               (~optional -bounds:BoundsClass)
-              (~optional (~seq where-blocks:TestConstructClass ...))
-              )
+              where-blocks:TestConstructClass ...)
       #:with prop-name #'-prop-name.name
       #:with pred-name #'-pred-name.name
       #:with constraint-type (string->symbol (syntax-e #'ct))

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -309,8 +309,8 @@
               prop-expr:BlockClass
               (~optional -scope:ScopeClass)
               (~optional -bounds:BoundsClass)
-              "where"
-              where-blocks:TestConstructClass ...)
+              (~optional (~seq where-blocks:TestConstructClass ...))
+              )
       #:with prop-name #'-prop-name.name
       #:with pred-name #'-pred-name.name
       #:with constraint-type (string->symbol (syntax-e #'ct))

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -64,7 +64,6 @@ underconstraint emptyofone of isUndirectedTree
     (no edges)
  } 
  for 1 Node
- where {}
 
 
 // Section 2: Testing Valid, simple overconstraints


### PR DESCRIPTION
Authors no longer have to specify empty where blocks, which are a little awkward. This reduces the nudge to fill examples for each property if not needed.