### PR TITLE
Improving property test names

### DIFF
--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -759,13 +759,20 @@
   [pwd:PropertyWhereDeclClass
    
     ;; Figure out LHS and RHS (this is ugly, will)
-  #:with imp_lhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.prop-name #:source stx) (format-id stx "~a" #'pwd.pred-name #:source stx))
-  #:with imp_rhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.pred-name #:source stx) (format-id stx "~a" #'pwd.prop-name #:source stx))
-  #:with test_name (format-id stx "~a-implies-~a" #'imp_lhs #'imp_rhs)
+  ;; #:with imp_lhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.prop-name #:source stx) (format-id stx "~a" #'pwd.pred-name #:source stx))
+  ;; #:with imp_rhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.pred-name #:source stx) (format-id stx "~a" #'pwd.prop-name #:source stx))
+  ;; #:with test_name (format-id stx "~a-implies-~a" #'imp_lhs #'imp_rhs)
   
    #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;;; Overconstraint : Prop => Pred
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;;; Underconstraint Pred => Prop
+
+   #:with test_name (let* 
+                      ([imp (syntax->datum #'imp_total)]
+                       [opr (car imp)]
+                       [lhs (format "~a" (car (cdr imp)))]
+                       [rhs (format "~a" (car (cdr (cdr imp))))]) 
+                      (format-id stx "~a ~a ~a" lhs opr rhs ))   
    (syntax/loc stx
     (begin
       (pred pwd.prop-name pwd.prop-expr)

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -757,7 +757,12 @@
 (define-syntax (PropertyWhereDecl stx)
   (syntax-parse stx
   [pwd:PropertyWhereDeclClass
-   #:with test_name (format-id stx "~a-subproperty" #'pwd.prop-name #:source stx)
+   
+    ;; Figure out LHS and RHS (this is ugly, will)
+  #:with imp_lhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.prop-name #:source stx) (format-id stx "~a" #'pwd.pred-name #:source stx))
+  #:with imp_rhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.pred-name #:source stx) (format-id stx "~a" #'pwd.prop-name #:source stx))
+  #:with test_name (format-id stx "~a-implies-~a" #'imp_lhs #'imp_rhs)
+  
    #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;;; Overconstraint : Prop => Pred
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;;; Underconstraint Pred => Prop

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -12,6 +12,7 @@
 
 (provide isSeqOf seqFirst seqLast indsOf idxOf lastIdxOf elems inds isEmpty hasDups reachable)
 (require forge/choose-lang-specific)
+(require racket/list)
 
 
 (provide #%module-begin)
@@ -760,12 +761,8 @@
    #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;;; Overconstraint : Prop => Pred
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;;; Underconstraint Pred => Prop
-   #:with test_name (let* 
-                      ([imp (syntax->datum #'imp_total)]
-                       [opr (car imp)]
-                       [lhs (format "~a" (car (cdr imp)))]
-                       [rhs (format "~a" (car (cdr (cdr imp))))]) 
-                      (format-id stx "~a ~a ~a" lhs opr rhs ))   
+   #:with test_name (let ([imp (syntax->list #'imp_total)]) 
+                    (format-id stx "~a ~a ~a" (cadr imp) (car imp) (caddr imp)))   
    (syntax/loc stx
     (begin
       (pred pwd.prop-name pwd.prop-expr)

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -756,17 +756,10 @@
 ; PropertyWhereDecl : PROPERTY-TOK Name OF-TOK Name Expr WHERE-TOK TEST-CONSTRUCT*
 (define-syntax (PropertyWhereDecl stx)
   (syntax-parse stx
-  [pwd:PropertyWhereDeclClass
-   
-    ;; Figure out LHS and RHS (this is ugly, will)
-  ;; #:with imp_lhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.prop-name #:source stx) (format-id stx "~a" #'pwd.pred-name #:source stx))
-  ;; #:with imp_rhs (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint) (format-id stx "~a" #'pwd.pred-name #:source stx) (format-id stx "~a" #'pwd.prop-name #:source stx))
-  ;; #:with test_name (format-id stx "~a-implies-~a" #'imp_lhs #'imp_rhs)
-  
+  [pwd:PropertyWhereDeclClass 
    #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;;; Overconstraint : Prop => Pred
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;;; Underconstraint Pred => Prop
-
    #:with test_name (let* 
                       ([imp (syntax->datum #'imp_total)]
                        [opr (car imp)]

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -12,7 +12,7 @@
 
 (provide isSeqOf seqFirst seqLast indsOf idxOf lastIdxOf elems inds isEmpty hasDups reachable)
 (require forge/choose-lang-specific)
-(require racket/list)
+(require (for-syntax racket/match))
 
 
 (provide #%module-begin)
@@ -761,8 +761,8 @@
    #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'overconstraint)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;;; Overconstraint : Prop => Pred
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;;; Underconstraint Pred => Prop
-   #:with test_name (let ([imp (syntax->list #'imp_total)]) 
-                    (format-id stx "~a ~a ~a" (cadr imp) (car imp) (caddr imp)))   
+   #:do [(match-define (list op lhs rhs) (syntax->list #'imp_total))]
+   #:with test_name (format-id stx "~a ~a ~a" lhs op rhs)
    (syntax/loc stx
     (begin
       (pred pwd.prop-name pwd.prop-expr)

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -57,8 +57,8 @@
     (list "failed_theorem.frg" #rx"failed.")
     (list "failed_unsat.frg" #rx"Failed test")
     (list "failed_sat.frg" #rx"Failed test") 
-    (list "properties_undirected_tree_underconstraint_error.frg" #rx"subproperty failed. Found instance")
-    (list "properties_undirected_tree_overconstraint_error.frg" #rx"subproperty failed. Found instance")
+    (list "properties_undirected_tree_underconstraint_error.frg" #rx" failed. Found instance")
+    (list "properties_undirected_tree_overconstraint_error.frg" #rx" failed. Found instance")
   ))
 
 ;; -----------------------------------------------------------------------------

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -57,8 +57,8 @@
     (list "failed_theorem.frg" #rx"failed.")
     (list "failed_unsat.frg" #rx"Failed test")
     (list "failed_sat.frg" #rx"Failed test") 
-    (list "properties_undirected_tree_underconstraint_error.frg" #rx" failed. Found instance")
-    (list "properties_undirected_tree_overconstraint_error.frg" #rx" failed. Found instance")
+    (list "properties_undirected_tree_underconstraint_error.frg" #rx"isUndirectedTree implies TreeWithEdges failed. Found instance")
+    (list "properties_undirected_tree_overconstraint_error.frg" #rx"isUndirected implies isUndirectedTree failed. Found instance")
   ))
 
 ;; -----------------------------------------------------------------------------


### PR DESCRIPTION
Property Tests now are of the form <name>-implies<name>. Error messages are now of the form:
```
Theorem isUndirected-implies-isUndirectedTree failed. Found instance:
```