### PR TITLE
Logging 2023

### DIFF
--- a/Notes/github-actions.txt
+++ b/Notes/github-actions.txt
@@ -8,5 +8,5 @@ The semantic version renaming action will look for the following tags, which cor
 [minor] (x.+.x)
 [patch] (x.x.+)
 
-Placing the correct tag in a commit message, pushing to a branch, making a pull request into master, and approving the request will run the action and increment the version number kept in info.rkt.
+Placing the correct tag in a commit message, pushing to a branch, making a pull request into main, and approving the request will run the action and increment the version number kept in info.rkt.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Forge
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/tnelson/Forge?label=version)
 ![GitHub issues](https://img.shields.io/github/issues/tnelson/Forge)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/tnelson/Forge/Continuous%20Integration/master?label=tests)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/tnelson/Forge/Continuous%20Integration/main?label=tests)
 
 Welcome to Forge! Forge is a tool and language built for **teaching** introductory formal methods and modeling.
 
@@ -22,7 +22,7 @@ For broader historical context on Forge, the [Alloy documentation
 ](http://alloytools.org/documentation.html) or an [Alloy demo](http://alloytools.org/tutorials/day-course/) may be useful. We don't suggest using these as reference for Forge itself, however.
 
 ## Contributing
-To contribute, fork the repository (or open a new branch if a core contributor) and make your changes. When making a pull request back into master, please prepend the pull request title with one of `[patch]`, `[minor]`, or `[major]` so that the corresponding version number is updated. If no version update is specified, the minor version will be updated automatically.
+To contribute, fork the repository (or open a new branch if a core contributor) and make your changes. When making a pull request back into main, please prepend the pull request title with one of `[patch]`, `[minor]`, or `[major]` so that the corresponding version number is updated. If no version update is specified, the minor version will be updated automatically.
 
 
 ## Installation from source

--- a/forge/bsl/lang/reader.rkt
+++ b/forge/bsl/lang/reader.rkt
@@ -3,7 +3,7 @@
 (require syntax/parse)
 (require forge/lang/alloy-syntax/parser)
 (require forge/lang/alloy-syntax/tokenizer)
-(require (prefix-in log: forge/logging/2022/main))
+(require (prefix-in log: forge/logging/2023/main))
 
 (provide coerce-ints-to-atoms)
 (define (coerce-ints-to-atoms tree)
@@ -72,7 +72,7 @@
                   (define-namespace-anchor forge:n) ; Used for evaluator
                   (forge:nsa forge:n)
 
-                  (require (prefix-in log: forge/logging/2022/main))
+                  (require (prefix-in log: forge/logging/2023/main))
                   (require (only-in racket printf uncaught-exception-handler))
 
                   (require forge/choose-lang-specific)

--- a/forge/check-ex-spec/lang/reader.rkt
+++ b/forge/check-ex-spec/lang/reader.rkt
@@ -7,7 +7,7 @@
 (require forge/check-ex-spec/library)
 (require (only-in racket/function curry))
 (require racket/match)
-(require (prefix-in log: forge/logging/2022/main))
+(require (prefix-in log: forge/logging/2023/main))
 ; (require racket/list)
 
 (define (filter-commands stx keep)
@@ -59,7 +59,7 @@
                           (define-namespace-anchor forge:n)
                           (forge:nsa forge:n)
 
-                          (require (prefix-in log: forge/logging/2022/main))
+                          (require (prefix-in log: forge/logging/2023/main))
 
                           (parameterize ([uncaught-exception-handler (log:error-handler ',logging-on? ',compile-time (uncaught-exception-handler))])
                             (define wheat-results 

--- a/forge/core/lang/reader.rkt
+++ b/forge/core/lang/reader.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require racket/port)
-(require (prefix-in log: forge/logging/2022/main))
+(require (prefix-in log: forge/logging/2023/main))
 (require (prefix-in @ (only-in racket/base read-syntax)))
 
 (define (read-syntax path port)
@@ -22,7 +22,7 @@
                           (set-checker-hash! forge-checker-hash)
                           (set-ast-checker-hash! forge-ast-checker-hash)                          
 
-                          (require (prefix-in log: forge/logging/2022/main))
+                          (require (prefix-in log: forge/logging/2023/main))
                           (require (only-in racket first rest empty? empty)) ; these are used heavily
                           (require forge/sigs)
 

--- a/forge/lang/reader.rkt
+++ b/forge/lang/reader.rkt
@@ -3,7 +3,7 @@
 (require syntax/parse)
 (require "alloy-syntax/parser.rkt")
 (require "alloy-syntax/tokenizer.rkt")
-(require (prefix-in log: forge/logging/2022/main))
+(require (prefix-in log: forge/logging/2023/main))
 
 (provide coerce-ints-to-atoms)
 (define (coerce-ints-to-atoms tree)
@@ -72,7 +72,7 @@
                   (define-namespace-anchor forge:n) ; Used for evaluator
                   (forge:nsa forge:n)
 
-                  (require (prefix-in log: forge/logging/2022/main))
+                  (require (prefix-in log: forge/logging/2023/main))
                   (require (only-in racket printf uncaught-exception-handler))
 
                   (require forge/choose-lang-specific)

--- a/forge/logging/2023/README.md
+++ b/forge/logging/2023/README.md
@@ -1,0 +1,36 @@
+2023
+===
+
+Simple logging for 2023.
+
+Goal = capture programs & errors.
+
+Implementation:
+
+- keep a local append-only log with file snapshots
+- write 1 log to this file per run of anything: cxs or otherwise
+- try to post the current log & any failed logs after a run
+
+(based on forge/logging/check-ex-spec/)
+
+
+## GCloud URL
+
+https://console.cloud.google.com/home/dashboard?project=pyret-examples&authuser=2
+
+## MySQL DB
+
+instance lfs2023
+password drracket
+
+mysql> use lfs2023;
+mysql> select count(1) from main;
+mysql> select student, project from main;
+
+
+## Cloud Function
+
+- name = submit
+- trigger = https://us-central1-pyret-examples.cloudfunctions.net/submit
+- source = index.js (here)
+- deps = package.js (here)

--- a/forge/logging/2023/index.js
+++ b/forge/logging/2023/index.js
@@ -1,0 +1,114 @@
+const PROJECT_ID = "pyret-examples";
+const SQL_ID = "lfs2023";
+const DATABASE = "lfs2023";
+const TABLE_ID = "main";
+const TABLE_ADDR = "35.231.81.85";
+
+const mysql = require("mysql");
+
+const Firestore = require('@google-cloud/firestore');
+const COLLECTION_NAME = 'events';
+
+function getSQLConnection () {
+  const options = 
+  {
+    host: TABLE_ADDR,
+    socketPath: "/cloudsql/" + PROJECT_ID + ":us-east1:" + SQL_ID,
+    user: 'root',
+    password: 'drracket',
+    database: DATABASE
+  };
+  return mysql.createConnection(options);
+}
+
+function getFirestore () {
+  const options =
+  {
+    projectId: PROJECT_ID,
+    timestampsInSnapshots: true
+  };
+  return new Firestore(options);
+}
+
+exports.submit = (req, res) => {
+  //console.log("lfs2023 begin");
+  //console.log(req.body);
+  res.set('Access-Control-Allow-Origin', '*');
+  if (req.method === 'OPTIONS') {
+    // Send response to OPTIONS requests
+    res.set('Access-Control-Allow-Methods', 'POST');
+    res.set('Access-Control-Allow-Headers', 'Content-Type');
+    res.set('Access-Control-Max-Age', '3600');
+    res.status(204).send('');
+  } else if (req.method === 'POST') {
+    let data;
+    if (typeof(req.body) === 'string' || req.body instanceof String) {
+      try {
+        data = JSON.parse(req.body);
+      } catch (e) {
+        data = req.body;
+      }
+    } else if (req.body instanceof Object) {
+      data = req.body;
+    } else {
+      data = req.body;
+    }
+    //console.log("lfs2023 data ok")
+    const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    const timestamp = new Date().getTime();
+    //console.log("lfs2023 conn ok");
+    let conn;
+    let post;
+    if (data.payload) {
+      // Examplar data, send to firestore
+      conn = getFirestore();
+      post = {
+        ip: ip,
+        timestamp: timestamp,
+        app_timestamp: data.time,
+        session: data.session,
+        event: data.event,
+        email: data.email,
+        assignment: data.assignment,
+        payload: data.payload,
+      };
+      return conn.collection(COLLECTION_NAME)
+        .add(post)
+        .then(doc => {
+          return res.status(200).send({});
+        }).catch(err => {
+          console.error(err);
+          return res.status(500).send({ error: 'unable to store', err });
+        });
+    } else if (data.ts) {
+      conn = getSQLConnection();
+      // Forge data, send to SQL
+      post = {
+        ip: ip,
+        ts: data.ts,
+        local_id: data.local_id,
+        student: data.student,
+        lang: data.lang,
+        forgeversion: data.forgeversion,
+        project: data.project,
+        input: (data.input && data.input.charCodeAt(0) < 130 && data.input.charCodeAt(1) < 130 && data.input.charCodeAt(2) < 130 && data.input.charCodeAt(3) < 130) ? data.input : "",
+        output: data.output
+      };
+      //console.log("lfs2022x posting")
+      conn.query("INSERT INTO " + TABLE_ID + " SET ?", post, function(err, result) {
+        if (err) {
+          console.error(err);
+          conn.end();
+          return res.status(500).send({error: 'unable to post', err});
+        } else {
+          conn.end();
+          return res.status(200).send({});
+        }
+      });
+    } else {
+      conn.end();
+      return res.status(203).send({});
+    }
+  }
+};
+

--- a/forge/logging/2023/main.rkt
+++ b/forge/logging/2023/main.rkt
@@ -1,0 +1,230 @@
+#lang racket/base
+
+;; Logging tools:
+;; - "setup" checks for a student name + assignment name
+;; - "register" logs a file snapshot
+;; - "flush" does two things: appends wheat/chaff results and posts logs
+
+(provide
+  setup
+  ;; (-> (or/c string? #f)
+  ;;     port?
+  ;;     path-string?
+  ;;     (values (or/c #t #f)
+  ;;             (or/c string? #f)
+  ;;             (or/c string? #f)))
+
+  register-run
+  ;; (-> exact-nonnegative-integer?
+  ;;     (or/c string? #f)
+  ;;     (or/c symbol? #f)
+  ;;     (or/c string? #f)
+  ;;     (or/c path-string? #f)
+  ;;     void?)
+
+  flush-logs
+  ;; (-> exact-nonnegative-integer?
+  ;;     any/c
+  ;;     void?)
+
+  error-handler
+  ;; (-> boolean?
+  ;;     exn-handler?
+  ;;     exn-handler?)
+)
+
+(require
+  basedir
+  json
+  net/uri-codec
+  net/url
+  racket/list
+  sha
+  (only-in setup/getinfo get-info)
+  (only-in racket/format ~s ~r)
+  (only-in racket/string string-contains?)
+  (only-in racket/file make-parent-directory* file->string)
+  (only-in racket/port with-input-from-string peeking-input-port)
+  (only-in racket/path file-name-from-path path-only))
+
+;; -----------------------------------------------------------------------------
+
+(define trigger-url
+  (string->url
+    "https://us-central1-pyret-examples.cloudfunctions.net/submit"))
+
+(define forgeversion ((get-info '("forge")) 'version))
+
+(define MAX-POST 20)
+;; maximum number of POST requests to make during a flush
+
+(define (setup language port path)
+  (define peek-port (peeking-input-port port))
+  (define project (read peek-port))
+  (define user (read peek-port))
+  (close-input-port peek-port)
+  (if (and (string? project) (string? user))
+      (let ((got-data-file? (path-string? (get-log-file))))
+        (void (read port) (read port))
+        (define filename (format "~a" path))
+        (when (string-contains? filename "unsaved-editor")
+          (raise "Please save file before running."))
+        (define logged-name (format "~a.~a" (file-name-from-path path) 
+                                            (sha256 (string->bytes/utf-8 filename))))
+        (values got-data-file? project user))
+      (let ()
+        (if (equal? language 'forge/check-ex-spec)
+            (values #f (read port) #f)
+            (values #f #f #f)))))
+
+(define (register-run compile-time assignment-name lang user-name path)
+  (define log-file (and assignment-name lang user-name (path-string? path)
+                        (get-log-file)))
+  #;(printf "LOGFILE ~a~n" log-file)
+  (when log-file
+    #;(printf "REGISTER ~a~n" compile-time)
+    (with-handlers ((exn:fail? void))
+      (define log-data
+        (make-log compile-time assignment-name (symbol->string lang) user-name path))
+      (with-output-to-file log-file #:exists 'append
+        (lambda () (writeln log-data))))))
+
+(define (flush-logs compile-time output)
+  #;(printf "POST ~a~n" compile-time)
+  (define log-file (get-log-file))
+  #;(printf "LOG FILE ~s~n" log-file)
+  (when log-file
+    (define all-log*
+      (with-input-from-file log-file
+        (lambda ()
+          (for/list ((ln (in-lines)))
+            (string->value ln)))))
+    (define updated-log*
+      (for/list ((log (in-list all-log*)))
+        (if (and (pair? log)
+                 (equal? compile-time (log->compile-time log)))
+          (log-update-output log output)
+          log)))
+    (define *network-ok? (box #true))
+    (define *num-post (box 0))
+    (call-with-output-file log-file #:exists 'replace
+      (lambda (out-port)
+        (for ((log (in-list updated-log*))
+              (local-id (in-naturals)))
+          (cond
+            [(or (not (unbox *network-ok?))
+                 (not (pair? log))
+                 (log->posted? log)
+                 (<= MAX-POST (unbox *num-post)))
+             (writeln log out-port)]
+            [else
+             (with-handlers ([exn:fail:network? (lambda (x)
+                                                  (set-box! *network-ok? #false)
+                                                  #;(printf "EXN ~a~n" (exn-message x))
+                                                  (writeln log out-port))])
+               (define status (post-log (log->jsexpr log local-id)))
+               #;(printf "STATUS ~a~n" status)
+               (set-box! *num-post (+ 1 (unbox *num-post)))
+               (writeln (log-update-posted? log (success? status)) out-port))]))))))
+
+(define ((error-handler logging-on? compile-time default-exception-handler) err)
+  (when logging-on?
+    (flush-logs compile-time (if (exn? err) (exn-message err) (~s err))))
+  (default-exception-handler err))
+
+;; ---
+
+(define (get-log-file)
+  (with-handlers ([exn:fail? (lambda (x) #false)])
+    (let* ([fn (writable-config-file "lfs2023.rktd" #:program "forge")])
+      (unless (file-exists? fn)
+        (make-parent-directory* fn)
+        (file-or-directory-permissions (path-only fn) #o777)
+        (with-output-to-file fn void))
+      fn)))
+
+(define (make-log compile-time assignment-name lang user-name path)
+  (define compressed-file (compress-and-anonymize path))
+  (list #false compile-time assignment-name lang forgeversion user-name compressed-file #false))
+
+(define (compress-and-anonymize path)
+  (define anon-filename (anonymize-path path))
+  (define mod-seconds (file-or-directory-modify-seconds path))
+  (format "~a	~a	~s" anon-filename mod-seconds (file->string path)))
+
+(define (anonymize-path path)
+  (let* ((str (if (path? path) (path->string path) path))
+         (ext (format ".~a" (equal-hash-code str))))
+    (path->string
+      (path-add-extension (file-name-from-path path) ext #"."))))
+
+;; bg: maybe should be a prefab struct
+(define log->posted? first)
+(define log->compile-time second)
+(define log->project third)
+(define log->lang fourth)
+(define log->forgeversion fifth) ;; store this, in case version changes between compile & run
+(define log->student sixth)
+(define log->input seventh)
+(define log->output eighth)
+
+(define (log-update-posted? log bool)
+  (cons bool (cdr log)))
+
+(define (log-update-output log output)
+  ;; update last element
+  (if (not (pair? log))
+    log ;; malformed input
+    (let loop ((x* log)) ;; replace final element
+      (if (null? (cdr x*))
+        (list (~s output))
+        (cons (car x*) (loop (cdr x*)))))))
+
+(define (string->value str)
+  (with-handlers ([exn:fail:read? (lambda (x) #false)])
+    (with-input-from-string str read)))
+
+;; ---
+
+(define (success? response-status)
+  (regexp-match? #"2[0-9][0-9]" response-status))
+
+(define (log->jsexpr log local-id)
+  (hash
+    'local_id local-id
+    'ts (seconds->timestamp (log->compile-time log))
+    'student (log->student log)
+    'lang (log->lang log)
+    'forgeversion (log->forgeversion log)
+    'project (log->project log)
+    'input (log->input log)
+    'output (log->output log)))
+
+(define (seconds->timestamp n)
+  (date->iso-8601 (seconds->date n)))
+
+(define (date->iso-8601 dd)
+  (format "~a-~a-~a ~a:~a:~a"
+          (date-year dd)
+          (~r2 (date-month dd))
+          (~r2 (date-day dd))
+          (~r2 (date-hour dd))
+          (~r2 (date-minute dd))
+          (~r2 (date-second dd))))
+
+(define (~r2 n)
+  (~r n #:min-width 2 #:pad-string "0"))
+
+(define (post-log js)
+  (define str (jsexpr->string js))
+  (define-values [status head* inp]
+    (http-sendrecv/url
+      trigger-url
+      #:method "POST"
+      #:data str
+      #:headers (list "Content-Type: application/json; charset=UTF-8")))
+  (close-input-port inp)
+  status)
+
+
+

--- a/forge/logging/2023/package.js
+++ b/forge/logging/2023/package.js
@@ -1,0 +1,9 @@
+{
+  "name": "submit",
+  "version": "0.0.1",
+  "dependencies": {
+    "mysql": "2.18.1",
+    "@google-cloud/firestore": "3.8.6"
+  }
+}
+

--- a/forge/logging/2023/schema.sql
+++ b/forge/logging/2023/schema.sql
@@ -1,0 +1,29 @@
+/* SQL schema, hosted on Google Cloud
+ * project = pyret-examples
+ *
+ * SQL ID = lfs2023
+ * password = drracket
+ * connection name = pyret-examples:us-east1:lfs2023
+ * public IP = 35.231.81.85
+ *
+ * To connect using the `gcloud` script:
+ *  $ ./google-cloud-sdk/bin/gcloud sql connect lfs2023 -d lfs2023 -u root
+ * then enter the password
+ * then enter the table name "main"
+ */
+
+/* CREATE DATABASE lfs2023; */
+
+CREATE TABLE main (
+ id serial PRIMARY KEY,
+ ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ ip CHAR(40),
+ local_id INT UNSIGNED,
+ student VARCHAR(60),
+ forgeversion CHAR(40),
+ lang VARCHAR(60),
+ project VARCHAR(60),
+ input MEDIUMTEXT,
+ output MEDIUMTEXT
+);
+


### PR DESCRIPTION
Enable logging for 2023

Example:

```
#lang forge "test" "ben"

option run_sterling off

sig Thang {}
run {}
```

Compiling this file adds a line to a local config file (`~/.config/forge/lfs2023.rktd` for me). Running the file posts the line + any runtime error to the DB.

Looks good for simple files. The DB has some entries now:

```
mysql> use lfs2023;
mysql> select count(1) from main;
+----------+
| count(1) |
+----------+
|        7 |
+----------+
1 row in set (0.00 sec)
```