### PR TITLE
Syntax Update -- Property/Where syntax in terms of necessary and sufficient

### DIFF
--- a/forge/examples/property-where/undirected_tree_properties.rkt
+++ b/forge/examples/property-where/undirected_tree_properties.rkt
@@ -15,10 +15,11 @@ pred isUndirectedTree {
 
 
 
- isUndirected of isUndirectedTree
+ assert isUndirected 
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } is underconstraint
+ } 
+ is necessary for isUndirectedTree
  where {
 
 
@@ -52,9 +53,9 @@ pred isUndirectedTree {
 
 
 
-emptyofone of isUndirectedTree
+assert emptyofone
  {
     (no edges)
- } is underconstraint
+ } is sufficient for isUndirectedTree
  for 1 Node
- where { }
+

--- a/forge/examples/property-where/undirected_tree_properties.rkt
+++ b/forge/examples/property-where/undirected_tree_properties.rkt
@@ -15,10 +15,10 @@ pred isUndirectedTree {
 
 
 
- underconstraint isUndirected of isUndirectedTree
+ isUndirected of isUndirectedTree
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } 
+ } is underconstraint
  where {
 
 
@@ -46,28 +46,15 @@ pred isUndirectedTree {
             Node = `Node0 + `Node1
             edges = `Node0->`Node0
         }
-
-
-        /*
-        //Nesting not currently supported.
-        underconstraint reachability of isUndirected
-        {
-            all m, n : Node | n->m in edges implies m in n.*edges
-        }
-        where
-        {}
-        */
 }
 
 
 
 
 
-underconstraint emptyofone of isUndirectedTree
+emptyofone of isUndirectedTree
  {
     (no edges)
- } 
+ } is underconstraint
  for 1 Node
- where {
-       
-}
+ where { }

--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -115,8 +115,8 @@
    ["break"     (token+ `BREAK-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
    ;; Property of where
-   ["overconstraint"     (token+ `OVERCONSTRAINT-TOK "" lexeme "" lexeme-start lexeme-end)]  
-   ["underconstraint"     (token+ `UNDERCONSTRAINT-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["sufficient"     (token+ `SUFFICIENT-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["necessary"     (token+ `NECESSARY-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["of"     (token+ `OF-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["where"     (token+ `WHERE-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
@@ -235,8 +235,8 @@
            "break"
 
 
-           "overconstraint"
-           "underconstraint"
+           "sufficient"
+           "necessary"
            "of"
            "where"
            

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -78,7 +78,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
-PropertyWhereDecl : Name /OF-TOK Name Block /IS-TOK (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
+PropertyWhereDecl : /ASSERT-TOK Name Block /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
 
 @TestConstruct : ExampleDecl | TestExpectDecl
 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -78,7 +78,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
-PropertyWhereDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
+PropertyWhereDecl : Name /OF-TOK Name Block /IS-TOK (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
 
 @TestConstruct : ExampleDecl | TestExpectDecl
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -300,12 +300,11 @@
   ;; PropertyWhereDecl : PROPERTY-TOK Name OF-TOK Name Block? WHERE-TOK? Block?
   (define-syntax-class PropertyWhereDeclClass
     #:attributes (prop-name pred-name prop-expr constraint-type scope bounds (where-blocks 1))
-    (pattern ((~literal PropertyWhereDecl)
-              (~and (~or "overconstraint" "underconstraint") ct)
+    (pattern ((~literal PropertyWhereDecl)          
               -prop-name:NameClass
-              "of"
               -pred-name:NameClass
               prop-expr:BlockClass
+              (~and (~or "overconstraint" "underconstraint") ct)
               (~optional -scope:ScopeClass)
               (~optional -bounds:BoundsClass)
               where-blocks:TestConstructClass ...)

--- a/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
@@ -16,10 +16,10 @@ pred isUndirectedTree {
 
 // This is an underconstraint, not an overconstraint.
 
- isUndirected of isUndirectedTree
+ assert isUndirected
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } is overconstraint
+ } is sufficient for isUndirectedTree
  where { }
 
 

--- a/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
@@ -16,10 +16,10 @@ pred isUndirectedTree {
 
 // This is an underconstraint, not an overconstraint.
 
- overconstraint isUndirected of isUndirectedTree
+ isUndirected of isUndirectedTree
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } 
+ } is overconstraint
  where { }
 
 

--- a/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
@@ -16,7 +16,7 @@ pred isUndirectedTree {
 
 // This is an overconstraint, not an underconstraint.
 
-TreeWithEdges of isUndirectedTree
+assert TreeWithEdges
  {
     edges = ~edges // Symmetric 
     Node->Node in *edges // Connected
@@ -29,7 +29,7 @@ TreeWithEdges of isUndirectedTree
     }
 
     some edges
- } is underconstraint
+ } is necessary for isUndirectedTree
  where  { }
 
  

--- a/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
@@ -15,7 +15,7 @@ pred isUndirectedTree {
 
 // This is an overconstraint, not an underconstraint.
 
-underconstraint TreeWithEdges of isUndirectedTree
+TreeWithEdges of isUndirectedTree
  {
     edges = ~edges // Symmetric 
     Node->Node in *edges // Connected
@@ -28,7 +28,7 @@ underconstraint TreeWithEdges of isUndirectedTree
     }
 
     some edges
- } 
+ } is underconstraint
  where  { }
 
  

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -16,10 +16,10 @@ pred isUndirectedTree {
 
 // Section 1: Testing Valid, simple underconstraints
 
- underconstraint isUndirected of isUndirectedTree
+ isUndirected of isUndirectedTree
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } 
+ } is underconstraint
  where {
 
         test expect {
@@ -45,30 +45,18 @@ pred isUndirectedTree {
             Node = `Node0 + `Node1
             edges = `Node0->`Node0
         }
-
-
-        /*
-        //Nesting not currently supported.
-        underconstraint reachability of isUndirected
-        {
-            all m, n : Node | n->m in edges implies m in n.*edges
-        }
-        where
-        {}
-        */
 }
 
 
-underconstraint emptyofone of isUndirectedTree
+emptyofone of isUndirectedTree
  {
     (no edges)
- } 
- for 1 Node
+ } is underconstraint for 1 Node
 
 
 // Section 2: Testing Valid, simple overconstraints
 
-overconstraint TreeWithEdges of isUndirectedTree
+TreeWithEdges of isUndirectedTree
  {
     edges = ~edges // Symmetric 
     Node->Node in *edges // Connected
@@ -81,23 +69,23 @@ overconstraint TreeWithEdges of isUndirectedTree
     }
 
     some edges
- } 
+ } is overconstraint
  where  { }
 
 // Section 3: Self
 
 
-overconstraint foo of isUndirectedTree
+ foo of isUndirectedTree
  {
    isUndirectedTree
- } 
- where  {}
+ } is overconstraint
 
-underconstraint bar of isUndirectedTree
+
+bar of isUndirectedTree
  {
    isUndirectedTree
- } 
- where  {}
+ } is underconstraint
+
 
 
 

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -16,10 +16,10 @@ pred isUndirectedTree {
 
 // Section 1: Testing Valid, simple underconstraints
 
- isUndirected of isUndirectedTree
+assert isUndirected 
  {
      all m, n : Node | n->m in edges implies m->n in edges
- } is underconstraint
+ } is necessary for isUndirectedTree
  where {
 
         test expect {
@@ -48,15 +48,15 @@ pred isUndirectedTree {
 }
 
 
-emptyofone of isUndirectedTree
+assert emptyofone
  {
     (no edges)
- } is underconstraint for 1 Node
+ } is necessary for isUndirectedTree for 1 Node
 
 
 // Section 2: Testing Valid, simple overconstraints
 
-TreeWithEdges of isUndirectedTree
+assert TreeWithEdges
  {
     edges = ~edges // Symmetric 
     Node->Node in *edges // Connected
@@ -69,22 +69,19 @@ TreeWithEdges of isUndirectedTree
     }
 
     some edges
- } is overconstraint
- where  { }
+ } is sufficient for isUndirectedTree
 
 // Section 3: Self
-
-
- foo of isUndirectedTree
+assert foo
  {
    isUndirectedTree
- } is overconstraint
+ } is sufficient for isUndirectedTree
 
 
-bar of isUndirectedTree
+assert bar
  {
    isUndirectedTree
- } is underconstraint
+ } is necessary for isUndirectedTree
 
 
 


### PR DESCRIPTION
Tests now take a form that more transparently shows the implicit implications.  Perhaps we could call these conditional hypotheses instead of property/where tests?

```
assert p { ...} is necessary for q for {...bounds... / scope}
where 
{ }

assert p { ...} is sufficient for q for {...bounds... / scope}
where 
{ }
```
