### PR TITLE
lang to hide wheat code

### DIFF
--- a/forge/decode-wheat-lang/encode-wheat.rkt
+++ b/forge/decode-wheat-lang/encode-wheat.rkt
@@ -8,12 +8,13 @@
   (define bb (string->bytes/utf-8 str))
   (void
     (for ((i (in-range (bytes-length bb))))
-      (bytes-set! bb i (modulo (+ (bytes-ref bb i) offset) 256))))
+      (bytes-set! bb i (encode-byte (bytes-ref bb i)))))
   (define out out-file)
   (with-output-to-file out #:exists 'replace
     (lambda ()
-      (displayln "#lang forge/decode-wheat-lang")
-      (write-bytes bb)))
+      (display "#lang forge/decode-wheat-lang\t")
+      (write-bytes bb)
+      (void)))
   (void))
 
 (module+ main

--- a/forge/decode-wheat-lang/encode-wheat.rkt
+++ b/forge/decode-wheat-lang/encode-wheat.rkt
@@ -4,7 +4,7 @@
 
 (define (encode in-file out-file)
   (define ln* (cdr (file->lines in-file)))
-  (define str (string-join ln* ))
+  (define str (string-join (cdr ln*) "\n"))
   (define bb (string->bytes/utf-8 str))
   (void
     (for ((i (in-range (bytes-length bb))))

--- a/forge/decode-wheat-lang/encode-wheat.rkt
+++ b/forge/decode-wheat-lang/encode-wheat.rkt
@@ -1,0 +1,25 @@
+#lang racket
+
+(require forge/decode-wheat-lang/util)
+
+(define (encode in-file out-file)
+  (define ln* (cdr (file->lines in-file)))
+  (define str (string-join ln* ))
+  (define bb (string->bytes/utf-8 str))
+  (void
+    (for ((i (in-range (bytes-length bb))))
+      (bytes-set! bb i (modulo (+ (bytes-ref bb i) offset) 256))))
+  (define out out-file)
+  (with-output-to-file out #:exists 'replace
+    (lambda ()
+      (displayln "#lang forge/decode-wheat-lang")
+      (write-bytes bb)))
+  (void))
+
+(module+ main
+  (require racket/cmdline)
+  (command-line
+    #:program "encode-wheat"
+    #:args (in-file out-file)
+    (encode in-file out-file)))
+

--- a/forge/decode-wheat-lang/lang/reader.rkt
+++ b/forge/decode-wheat-lang/lang/reader.rkt
@@ -7,22 +7,23 @@
   forge/decode-wheat-lang/util
   (prefix-in f: forge/lang/reader))
 
-;;; TODO secret prefix
+(define TAB 9)
 
 (define (read-syntax path port)
-  (f:read-syntax path (filter-read-input-port port rr pp)))
+  (f:read-syntax path (filter-read-input-port port dread dpeek)))
 
-(define (rr bb res)
-  (when (and (exact-nonnegative-integer? res)
-           (< 0 res))
-    (for ((i (in-range res)))
-      (bytes-set! bb i (modulo (- (bytes-ref bb i) offset) 256))))
+(define (dread b* res)
+  (decode-bytes! b* res)
   res)
 
-(define (pp bb ii evt res)
-  (when (and (exact-nonnegative-integer? res)
-           (< 0 res))
-    (for ((i (in-range res)))
-      (bytes-set! bb i (modulo (- (bytes-ref bb i) offset) 256))))
+(define (dpeek b* _i _evt res)
+  (decode-bytes! b* res)
   res)
+
+(define (decode-bytes! b* res)
+  (when (and (exact-nonnegative-integer? res)
+             (< 0 res))
+    (for ((i (in-range res))
+          #:unless (and (= 0 i) (= TAB (bytes-ref b* i))))
+      (bytes-set! b* i (decode-byte (bytes-ref b* i))))))
 

--- a/forge/decode-wheat-lang/lang/reader.rkt
+++ b/forge/decode-wheat-lang/lang/reader.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+(provide read-syntax)
+
+(require
+  racket/port
+  forge/decode-wheat-lang/util
+  (prefix-in f: forge/lang/reader))
+
+;;; TODO secret prefix
+
+(define (read-syntax path port)
+  (f:read-syntax path (filter-read-input-port port rr pp)))
+
+(define (rr bb res)
+  (when (and (exact-nonnegative-integer? res)
+           (< 0 res))
+    (for ((i (in-range res)))
+      (bytes-set! bb i (modulo (- (bytes-ref bb i) offset) 256))))
+  res)
+
+(define (pp bb ii evt res)
+  (when (and (exact-nonnegative-integer? res)
+           (< 0 res))
+    (for ((i (in-range res)))
+      (bytes-set! bb i (modulo (- (bytes-ref bb i) offset) 256))))
+  res)
+

--- a/forge/decode-wheat-lang/util.rkt
+++ b/forge/decode-wheat-lang/util.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(provide offset)
+
+(define offset 1)

--- a/forge/decode-wheat-lang/util.rkt
+++ b/forge/decode-wheat-lang/util.rkt
@@ -1,5 +1,16 @@
 #lang racket/base
 
-(provide offset)
+(provide encode-byte decode-byte)
 
-(define offset 1)
+(define offset 13)
+(define base 256)
+
+(define (encode-byte bb)
+  (rotate-byte bb +))
+
+(define (decode-byte bb)
+  (rotate-byte bb -))
+
+(define (rotate-byte bb op)
+  (modulo (op bb offset) base))
+


### PR DESCRIPTION
@sidprasad please test this on your machine

1. Start with a test file and a source-code wheat
2. Run `encode-wheat.rkt PATH-TO-WHEAT hidden.rkt`
3. Change the test file to import `hidden.rkt`. It should run just like before!

If it works, we can go ahead. But I have a few concerns about this PR:
- [x] `offset = 1` is the only one I've gotten to work. `3` and `19` don't work ... is `1` going to break on other wheat files? EDIT: wow that was nasty ... I was decoding the space between the `#lang` and the encrypted body ... for tiny offsets it was fine b/c all whitespace
- [ ] The decoder should look for a secret key at the start of each file. (Right now it decodes ANY file and sends it to Forge, which means students can try decoding things to reverse engineer it. Using a secret key will make it a little harder to play with.)
- [x] gotta allow comments in the wheat; make sure it works with those

Can we think of other threats?