### PR TITLE
Replacing where blocks with test-suite construct

### DIFF
--- a/forge/examples/property-where/undirected_tree_properties.rkt
+++ b/forge/examples/property-where/undirected_tree_properties.rkt
@@ -19,12 +19,13 @@ pred isUndirectedTree {
  {
      all m, n : Node | n->m in edges implies m->n in edges
  } 
- where {
-
-
+ 
+ 
+ test suite for isUndirected {
         test expect {
 
             {isUndirected} is sat
+            {one Node} is sat // Raises warning but not error.
         }
 
         example line is {not isUndirected} for {
@@ -46,17 +47,6 @@ pred isUndirectedTree {
             Node = `Node0 + `Node1
             edges = `Node0->`Node0
         }
-
-
-        /*
-        //Nesting not currently supported.
-        underconstraint reachability of isUndirected
-        {
-            all m, n : Node | n->m in edges implies m in n.*edges
-        }
-        where
-        {}
-        */
 }
 
 
@@ -68,6 +58,4 @@ underconstraint emptyofone of isUndirectedTree
     (no edges)
  } 
  for 1 Node
- where {
-       
-}
+

--- a/forge/examples/property-where/undirected_tree_properties.rkt
+++ b/forge/examples/property-where/undirected_tree_properties.rkt
@@ -23,11 +23,12 @@ pred isUndirectedTree {
  
  test suite for isUndirected {
         test expect {
-
-            {isUndirected} is sat
-            {one Node} is sat // Raises warning but not error.
+            {isUndirected} is sat   
         }
 
+        test expect {
+           {one Node} is sat // Raises warning but not error.
+        }
         example line is {not isUndirected} for {
             Node = `Node0 + `Node1 + `Node2
             edges = `Node0->`Node1 + `Node1->`Node2 

--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -118,7 +118,7 @@
    ["overconstraint"     (token+ `OVERCONSTRAINT-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["underconstraint"     (token+ `UNDERCONSTRAINT-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["of"     (token+ `OF-TOK "" lexeme "" lexeme-start lexeme-end)]  
-   ["where"     (token+ `WHERE-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["suite"     (token+ `SUITE-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
    ;["state"     (token+ `STATE-TOK "" lexeme "" lexeme-start lexeme-end)]
    ;["facts"     (token+ `STATE-TOK "" lexeme "" lexeme-start lexeme-end)]  
@@ -238,7 +238,7 @@
            "overconstraint"
            "underconstraint"
            "of"
-           "where"
+           "suite"
            
            ;"state"
            ;"facts"

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -42,7 +42,8 @@ Import : /OPEN-TOK QualName (LEFT-SQUARE-TOK QualNameList RIGHT-SQUARE-TOK)? (AS
           | OptionDecl
           | InstDecl
           | ExampleDecl 
-          | PropertyWhereDecl
+          | PropertyDecl
+          | TestSuiteDecl
 
 ; NOTE: When extending sigs with "in" (subset sigs) is implemented,
 ;  if "sig A in B extends C" is allowed, update this to allow multiple SigExt
@@ -78,7 +79,9 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
-PropertyWhereDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? (/WHERE-TOK /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK)?
+PropertyDecl : (OVERCONSTRAINT-TOK | UNDERCONSTRAINT-TOK) Name OF-TOK Name Block Scope? (/FOR-TOK Bounds)? 
+
+TestSuiteDecl : /TEST-TOK /SUITE-TOK /FOR-TOK Name /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK
 
 @TestConstruct : ExampleDecl | TestExpectDecl
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -796,7 +796,7 @@
             (if (string-contains? ast-str tp) ;; Using string-contains for now.
               (void)
               (println 
-                (format "Warning: ~a ~a:~a Test in where block does not reference ~a." 
+                (format "Warning: ~a ~a:~a Test does not reference ~a." 
                   (syntax-source ex) (syntax-line ex) (syntax-column ex)  tp) 
                 (current-error-port))))))))
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -781,7 +781,8 @@
 ;; Flattens test AST to a string and ensures that the
 ;; referenced predicate's name is present.
 ;; Could be done better by traversing the AST.
-
+;; This would help break apart test-expect
+;; blocks and examine each test.
 
 (define-for-syntax (ensure-target-ref target-pred)
 
@@ -794,31 +795,13 @@
           (syntax-source ex) (syntax-line ex) (syntax-column ex)  tp)))))
 
 
-;;; (define-for-syntax (ensure-target-ref target-pred)
-;;;   (lambda (
-;;;     (let 
-;;;       ([tp (format "~a" (syntax->datum target-pred))])
-;;;         (lambda (ex) 
-;;;           (let*
-;;;             ([ex-as-datum (syntax->datum ex)]
-;;;               [ast-str  (format "~a" ex-as-datum)])
-;;;             (if (string-contains? ast-str tp) ;; Using string-contains for now.
-;;;               (void)
-;;;               (println 
-;;;                 (format "Warning: ~a ~a:~a Test does not reference ~a." 
-;;;                   (syntax-source ex) (syntax-line ex) (syntax-column ex)  tp) 
-;;;                 (current-error-port))))))))
-
-
 (define-syntax (TestSuiteDecl stx)
   (syntax-parse stx
   [tsd:TestSuiteDeclClass 
    
     ;; Static checks on test blocks go here.
-   #:do [
-      (for ([tc (syntax->list #'(tsd.test-constructs ...))])
-        ((ensure-target-ref #'tsd.pred-name) tc)) ]
-
+   #:do [(for ([tc (syntax->list #'(tsd.test-constructs ...))])
+        ((ensure-target-ref #'tsd.pred-name) tc))]
    (syntax/loc stx
     (begin tsd.test-constructs ...))]))
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -5,7 +5,7 @@
 
 (require syntax/parse/define
          (for-syntax racket/base syntax/parse racket/syntax syntax/parse/define racket/function
-                     syntax/srcloc racket/match)
+                     syntax/srcloc racket/match racket/string)
          ; Needed because the abstract-tok definition below requires phase 2
          (for-syntax (for-syntax racket/base)))
                  
@@ -322,7 +322,7 @@
     (pattern ((~literal TestSuiteDecl)
               -pred-name:NameClass
               test-constructs:TestConstructClass ...)
-      #:with pred-name #'-pred-name.name
+      #:with pred-name #'-pred-name.name))
 
   (define-syntax-class ExampleDeclClass
     (pattern ((~literal ExampleDecl)
@@ -806,10 +806,10 @@
   [tsd:TestSuiteDeclClass 
    
     ;; Static checks on test blocks go here.
-   #:do [(map (ensure-target-ref #'tsd.prop-name) (syntax->list #'(tsd.test-constructs ...)))]
+   #:do [(map (ensure-target-ref #'tsd.pred-name) (syntax->list #'(tsd.test-constructs ...)))]
 
    (syntax/loc stx
-    (begin pwd.where-blocks ...))]))
+    (begin tsd.test-constructs ...))]))
 
 
 (define-syntax (ExampleDecl stx)

--- a/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_overconstraint_error.frg
@@ -20,7 +20,7 @@ pred isUndirectedTree {
  {
      all m, n : Node | n->m in edges implies m->n in edges
  } 
- where { }
+ 
 
 
  

--- a/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
+++ b/forge/tests/error/properties_undirected_tree_underconstraint_error.frg
@@ -27,9 +27,6 @@ underconstraint TreeWithEdges of isUndirectedTree
             (n->m + m->n) in edges implies (n->m + m->n) not in ^(edges - (n->m + m->n))
         }
     }
-
     some edges
  } 
- where  { }
 
- 

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -23,10 +23,13 @@ pred isUndirectedTree {
  {
      all m, n : Node | n->m in edges implies m->n in edges
  } 
- where {
+
+
+test suite for isUndirected {
 
         test expect {
             {isUndirected} is sat
+            {one Node} is sat // This should result in a warning but not an error.
         }
 
         example line is {not isUndirected} for {
@@ -48,17 +51,6 @@ pred isUndirectedTree {
             Node = `Node0 + `Node1
             edges = `Node0->`Node0
         }
-
-
-        /*
-        //Nesting not currently supported.
-        underconstraint reachability of isUndirected
-        {
-            all m, n : Node | n->m in edges implies m in n.*edges
-        }
-        where
-        {}
-        */
 }
 
 
@@ -85,7 +77,7 @@ overconstraint TreeWithEdges of isUndirectedTree
 
     some edges
  } 
- where  { }
+
 
 // Section 3: Self
 
@@ -94,13 +86,12 @@ overconstraint foo of isUndirectedTree
  {
    isUndirectedTree
  } 
- where  {}
+
 
 underconstraint bar of isUndirectedTree
  {
    isUndirectedTree
  } 
- where  {}
 
 
 

--- a/forge/tests/forge/other/properties_undirected_tree.rkt
+++ b/forge/tests/forge/other/properties_undirected_tree.rkt
@@ -29,6 +29,9 @@ test suite for isUndirected {
 
         test expect {
             {isUndirected} is sat
+        }
+
+       test expect {
             {one Node} is sat // This should result in a warning but not an error.
         }
 


### PR DESCRIPTION
This change de-couples properties from substantiation tests. 

This means that property x of y no longer supports where blocks.

However, students can write test suites and annotate them as follows:

```

test suite for isUndirected {

        test expect {
            {isUndirected} is sat
        }

        example line is {not isUndirected} for {
            Node = `Node0 + `Node1 + `Node2
            edges = `Node0->`Node1 + `Node1->`Node2 
        }

        example empty is {isUndirected} for {
            Node = none
            edges = none->none
        }
}
```

Tests that do not reference the target property (in this case isUndirected) result in a warning, but not an error. Example warning:

```
"Warning: forge/forge/examples/property-where/undirected_tree_properties.rkt 25:8 Test does not reference isUndirected."
```