### PR TITLE
don't export unnamed tests / runs

### DIFF
--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -700,9 +700,9 @@
 (define-for-syntax make-temporary-name
   (let ((name-counter (box 1)))
     (lambda (stx)
-      (begin0
-        (format-id stx "temporary-name~a" (unbox name-counter) #:source stx)
-        (set-box! name-counter (+ 1 (unbox name-counter)))))))
+      (define curr-num (unbox name-counter))
+      (set-box! name-counter (+ 1 curr-num))
+      (string->symbol (format "temporary-name_~a" curr-num)))))
 
 ; CmdDecl :  (Name /COLON-TOK)? (RUN-TOK | CHECK-TOK) Parameters? (QualName | Block)? Scope? (/FOR-TOK Bounds)?
 (define-syntax (CmdDecl stx)

--- a/forge/tests/forge/other/open.frg
+++ b/forge/tests/forge/other/open.frg
@@ -1,6 +1,8 @@
 #lang forge
 
 open "other-file.frg"
+open "other-file2.frg"
+// both files have unnamed tests and runs
 
 option run_sterling off
 sig B extends A {}

--- a/forge/tests/forge/other/other-file2.frg
+++ b/forge/tests/forge/other/other-file2.frg
@@ -2,7 +2,7 @@
 
 option run_sterling off
 
-sig A {}
+sig C {}
 
 run {
   true
@@ -11,3 +11,4 @@ run {
 test expect {
   true is sat
 }
+

--- a/forge/tests/forge/other/other-file2.frg
+++ b/forge/tests/forge/other/other-file2.frg
@@ -11,4 +11,3 @@ run {
 test expect {
   true is sat
 }
-


### PR DESCRIPTION
Quick revert: for unnamed tests, use a symbol as a temporary name instead of an identifier.

When it's an identifier, it gets exported by the top-level `(provide (except-out ....))`. That leads to a conflict when one file imports two others.

Long term question: do we want unnamed tests to get provided?

cc @conradz