### PR TITLE
ci: revert froglet install, forge works for both

### DIFF
--- a/.github/workflows/continuousIntegration.yml
+++ b/.github/workflows/continuousIntegration.yml
@@ -20,7 +20,7 @@ jobs:
         java-version: '11'
     - name: Install Forge
       run: |
-        raco pkg install --auto --no-docs ./forge ./froglet
+        raco pkg install --auto --no-docs forge
     - name: Run tests
       run: |
         cd forge/


### PR DESCRIPTION
`raco pkg install forge` gets forge & froglet from the package server