### PR TITLE
restore the syntax-local-context of example blocks

### DIFF
--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -807,10 +807,10 @@
                            pred:ExprClass
                            bounds:BoundsClass)
    (quasisyntax/loc stx
-     (syntax-parameterize ([current-forge-context 'example])
-       (example (~? name.name unnamed-example)
-         pred
-         #,@(syntax/loc stx bounds.translate))))]))
+     (example (~? name.name unnamed-example)
+       pred
+       (syntax-parameterize ([current-forge-context 'example])
+         (begin #,@(syntax/loc stx bounds.translate)))))]))
 
 ; OptionDecl : /OPTION-TOK QualName (QualName | FILE-PATH-TOK | Number)
 (define-syntax (OptionDecl stx)

--- a/forge/tests/error/import-invalid-example.rkt
+++ b/forge/tests/error/import-invalid-example.rkt
@@ -1,0 +1,8 @@
+#lang forge
+
+open "invalid-example.frg"
+// Opening a file that contains an invalid example
+// should not cause the main file to fail
+
+// This file has a `.rkt` extension so the `run-tests.sh`
+// script finds it (even in the error/ folder)

--- a/forge/tests/error/invalid-example.frg
+++ b/forge/tests/error/invalid-example.frg
@@ -1,0 +1,11 @@
+#lang forge
+option run_sterling off
+
+sig Person {
+    age: one Int
+}
+
+example onlyBabies is {some p: Person | p.age < 3} for {
+    Person = `Person0
+    no age
+}

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -74,7 +74,7 @@
 ;    (list "froglet-uni-3.frg" #rx"Expected a sig")
 ;    (list "froglet-uni-4.frg" #rx"Expected a sig") ;; TODO reachable, double-check
 
-    (list "example_impossible.frg" #rx"impossible")
+    (list "example_impossible.frg" #rx"Invalid example 'onlyBabies'")
     (list "excluded-extender-value.frg" #rx"not a subset")
     (list "failed_sat.frg" #rx"Failed test")
     (list "failed_theorem.frg" #rx"failed.")

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -88,6 +88,7 @@
     (list "hello.frg" #rx"parsing error")
     (list "ill_typed_inst_columns_reversed.frg" #rx"age")
     (list "inst-undefined-bound-child-one.frg" #rx"for an ancestor of")
+    (list "invalid-example.frg" #rx"Invalid example 'onlyBabies'")
   ))
 
 


### PR DESCRIPTION
move the syntax-parameterize INSIDE the example form, so the whole thing still appears in a module context and the subterms get covered by the parameterize

(do we need to cover the pred too?)

@conradz