### PR TITLE
simpler wheat decoding

### DIFF
--- a/forge/decode-wheat-lang/encode-wheat.rkt
+++ b/forge/decode-wheat-lang/encode-wheat.rkt
@@ -12,7 +12,7 @@
   (define out out-file)
   (with-output-to-file out #:exists 'replace
     (lambda ()
-      (display "#lang forge/decode-wheat-lang\t")
+      (displayln "#lang forge/decode-wheat-lang")
       (write-bytes bb)
       (void)))
   (void))

--- a/forge/decode-wheat-lang/lang/reader.rkt
+++ b/forge/decode-wheat-lang/lang/reader.rkt
@@ -10,6 +10,7 @@
 (define TAB 9)
 
 (define (read-syntax path port)
+  (read-char port) ;; newline / tab
   (f:read-syntax path (filter-read-input-port port dread dpeek)))
 
 (define (dread b* res)
@@ -23,7 +24,6 @@
 (define (decode-bytes! b* res)
   (when (and (exact-nonnegative-integer? res)
              (< 0 res))
-    (for ((i (in-range res))
-          #:unless (and (= 0 i) (= TAB (bytes-ref b* i))))
+    (for ((i (in-range res)))
       (bytes-set! b* i (decode-byte (bytes-ref b* i))))))
 


### PR DESCRIPTION
instead of looking for a specific char at a specific point, drop the first (unencoded) character from the port after reading the lang

Low priority. If we find bugs in the original we can switch to this. Otherwise the original seems fine.