### PR TITLE
print git branch, commit, timestamp info

### DIFF
--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -43,7 +43,10 @@
   (when (and no-version-printed-yet (@>= (get-verbosity) VERBOSITY_LOW))
     (set! no-version-printed-yet #f)
     (printf "Forge version: ~a~n" forge-version)
-    (printf "To report issues with Forge, please visit ~a~n"           
+    (let ([git-info (forge-git-info)])
+      (when (pair? git-info)
+        (apply printf " branch: ~a~n commit: ~a~n timestamp: ~a~n" git-info)))
+    (printf "To report issues with Forge, please visit ~a~n"
             "https://report.forge-fm.org"))
   
   ; Do relation breaks from declarations

--- a/forge/shared.rkt
+++ b/forge/shared.rkt
@@ -33,19 +33,16 @@
 (define (get-verbosity) verbosityoption)
 (define (set-verbosity x) (set! verbosityoption x))
 
-(define (print-exn exn)
-  (println exn))
-
 (define-runtime-path info-path "info.rkt")
 (define forge-version "x.x.x")
-(with-handlers ([exn:fail? print-exn])
+(with-handlers ([exn:fail?  (λ (exn) (println exn))])
   (define info-str (file->string info-path))
   (define parts (regexp-match #px"define\\s+version\\s+\"(\\S+)\"" info-str))
   (set! forge-version (cadr parts))
 )
 
 (define (forge-git-info)
-  (with-handlers ([exn:fail? print-exn])
+  (with-handlers ([exn:fail? void])
     (define windows? (eq? (system-type) 'windows))
     (define git-exe (find-executable-path (if windows? "git.exe" "git")))
     (map

--- a/forge/shared.rkt
+++ b/forge/shared.rkt
@@ -5,7 +5,8 @@
          (only-in racket make-object)
          (only-in racket/system system*)
          (only-in racket/string string-trim)
-         (only-in racket/port call-with-output-string))
+         (only-in racket/port call-with-output-string)
+         (only-in pkg/lib pkg-directory))
 (require racket/stream)
 
 (provide get-verbosity set-verbosity
@@ -45,12 +46,13 @@
   (with-handlers ([exn:fail? void])
     (define windows? (eq? (system-type) 'windows))
     (define git-exe (find-executable-path (if windows? "git.exe" "git")))
-    (map
-      string-trim
-      (list
-        (shell git-exe '("rev-parse" "--abbrev-ref" "HEAD"))
-        (shell git-exe '("rev-parse" "--short" "HEAD"))
-        (shell git-exe '("log" "-1" "--format=%cd"))))))
+    (parameterize ([current-directory (pkg-directory "forge")])
+      (map
+        string-trim
+        (list
+          (shell git-exe '("rev-parse" "--abbrev-ref" "HEAD"))
+          (shell git-exe '("rev-parse" "--short" "HEAD"))
+          (shell git-exe '("log" "-1" "--format=%cd")))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Demo:
```
$ racket grandpa.frg
Forge version: 2.4.0
 branch: devinfo
 commit: f3c72c09
 timestamp: Tue Feb 14 12:22:58 2023 -0500
To report issues with Forge, please visit https://report.forge-fm.org
Sterling running. Hit enter to stop service.
#vars: (size-variables 1563); #primary: (size-primary 52); #clauses: (size-clauses 3076)
Transl (ms): (time-translation 282); Solving (ms): (time-solving 79)
```

Q:
- [x] Does it work on windows?
- [x] Does it fail silently for normal installs?
- [x] Beware, this will print the branch etc. for ANY git repo in the forge install happens to live inside of. Can we fix that? EDIT: oh, we might check the origin url for `tnelson/forge`
