### PR TITLE
fix: last check: multiple decls in one quantifier, minus operator RHS

### DIFF
--- a/forge/tests/forge/formulas/multipleDeclsInQuantifier.frg
+++ b/forge/tests/forge/formulas/multipleDeclsInQuantifier.frg
@@ -1,0 +1,23 @@
+#lang forge
+option verbose 0 
+
+sig NameSig {}
+sig ForwardTable { frows: set NameSig -> NameSig  }
+sig NetworkState {
+    members: set NameSig,
+    forwardingTables: set ForwardTable
+}
+
+// Decls are property carried forward into _domains_ of later quantifiers when checking
+pred demo {    
+    all thisState: NetworkState | 
+    let members = thisState.members | 
+    let forwardingTables = thisState.forwardingTables | 
+    {        
+        all m1: members, n: (forwardingTables.frows).m1 | m1 in NameSig and n in NameSig
+    }
+}
+
+test expect {
+    {demo} is sat
+}


### PR DESCRIPTION
(1) Quantifiers can contain multiple declarations. E.g., 
`some x: A, y: B | ...`
However, since `A` and `B` are arbitrary expressions, `B` can technically use the variable `x`. Our last-checker module does not currently add `(x A)` to the environment used for checking the expression `B`, resulting in a confusing error. This PR rolls the expanded environment forward across all decl domains, from left to right.

(2) Our last-checker module wasn't ever checking the right-hand side of a minus expression. Now if that exists, it's subjected to last-checker scrutiny.