### PR TITLE
semanticVersion: canonize major/minor numbers

### DIFF
--- a/.github/workflows/semanticVersionUpdater/read-version.py
+++ b/.github/workflows/semanticVersionUpdater/read-version.py
@@ -27,10 +27,10 @@ def updateVersion(curVersion, updateType, prerelease=None):
     if updateType == "major":
         major += 1
         minor = 0
-        patch = 0
+        patch = None
     elif updateType == "minor":
         minor += 1
-        patch = 0
+        patch = None
     elif updateType == "patch":
         patch += 1
     else:


### PR DESCRIPTION
Use 2.5 instead of 2.5.0 as a version number
Racket prefers this, to have a canonical normal form

Fix #204

@tnelson let's wait until summer to merge this