### PR TITLE
Retain sytnax loc

### DIFF
--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -515,7 +515,10 @@
     ; Join, atom name dotted with field name
     (pattern ((~datum BoundLHS) ((~datum AtomNameOrNumber) "`" atom:NameClass)                                
                                 field:QualNameClass)
-      #:attr translate (syntax/loc this-syntax (Expr (Expr "`" atom) "." (Expr field)))))
+      #:attr translate (quasisyntax/loc this-syntax
+                         (Expr
+                          #,(syntax/loc this-syntax (Expr "`" atom)) "."
+                          #,(syntax/loc this-syntax (Expr field))))))
   
   (define-syntax-class BoundClass
      #:description "bind declaration"
@@ -525,7 +528,7 @@
               op:CompareOpClass
               rhs:BindRHSUnionClass)
       #:attr translate (begin
-                         (syntax/loc this-syntax (Expr lhs.translate op rhs.translate))))
+                         (quasisyntax/loc this-syntax (Expr lhs.translate op rhs.translate))))
 
     ; cardinality bound (single relation): #LHS = N
     (pattern ((~datum Bound)  ; or backquote name
@@ -545,7 +548,12 @@
                              ((~datum BoundLHS)
                               ((~datum AtomNameOrNumber) "`" atom:NameClass)
                               field:QualNameClass))
-      #:attr translate (quasisyntax/loc this-syntax (Expr "no" (Expr (Expr "`" atom) "." (Expr field)))))
+      #:attr translate (quasisyntax/loc this-syntax
+                         (Expr "no"
+                               #,(quasisyntax/loc this-syntax
+                                   (Expr
+                                    #,(quasisyntax/loc this-syntax (Expr "`" atom)) "."
+                                    #,(quasisyntax/loc this-syntax (Expr field)))))))
 
     ; identifier: re-use of `inst` defined
     (pattern ((~datum Bound)  

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -735,40 +735,27 @@
                          (~optional abstract:abstract-tok)
                          (~optional mult:MultClass)
                          sig-names:NameListClass
-                         ;when extending with in is implemented,
-                         ;if "sig A in B extends C" is allowed,
-                         ;check if this allows multiple SigExtClasses / how to do that if not
-                         ;note the parser currently does not allow that
                          (~optional extends:SigExtClass)
                          (~optional block:BlockClass))
-     (syntax/loc stx (begin
+     (quasisyntax/loc stx (begin
        (~? (raise (format "Sig block not yet implemented: ~a" 'block)))
-       ;when extending with in is implemented,
-       ;if "sig A in B extends C" is allowed,
-       ;check if this allows that and update if needed
-       ;note the parser currently does not allow that
-       (sig (#:lang (get-check-lang)) sig-names.names (~? mult.symbol)
-                            (~? abstract.symbol)
-                            (~? (~@ #:is-var isv))
-                            (~? (~@ extends.symbol extends.value))) ...))]
+       #,@(for/list ([sig-name (syntax-e #'(sig-names.names ...))])
+            (with-syntax ([sig-name-p0 sig-name])
+              (syntax/loc sig-name
+                (sig (#:lang (get-check-lang)) sig-name-p0 (~? mult.symbol)
+                     (~? abstract.symbol)
+                     (~? (~@ #:is-var isv))
+                     (~? (~@ extends.symbol extends.value))))))))]
 
     [((~datum SigDecl) (~optional isv:VarKeywordClass #:defaults ([isv #'#f]))
                          (~optional abstract:abstract-tok)
                          (~optional mult:MultClass)
                          sig-names:NameListClass
-                         ;when extending with in is implemented,
-                         ;if "sig A in B extends C" is allowed,
-                         ;check if this allows multiple SigExtClasses / how to do that if not
-                         ;note the parser currently does not allow that
                          (~optional extends:SigExtClass)
                          ((~datum ArrowDeclList) arrow-decl:ArrowDeclClass ...)
                          (~optional block:BlockClass))
      (quasisyntax/loc stx (begin
        (~? (raise (format "Sig block not yet implemented: ~a" 'block)))
-       ;when extending with in is implemented,
-       ;if "sig A in B extends C" is allowed,
-       ;check if this allows that and update if needed
-       ;note the parser currently does not allow that
        #,@(for/list ([sig-name (syntax-e #'(sig-names.names ...))])
             (with-syntax ([sig-name-p0 sig-name])
               (syntax/loc sig-name

--- a/forge/lang/reader.rkt
+++ b/forge/lang/reader.rkt
@@ -46,13 +46,8 @@
     [(_ expr1 (~optional neg-tok) (CompareOp "<=") expr2)
      expr]
     [(parts ...)
-     (printf "r-i-e 'parts': ~a~n" expr)
-     (define r (replace-ints-expr* expr))
-     (printf "r-i-e 'parts' result: ~a~n" r)
-     r]
-    [_
-     (printf "r-i-e _: ~a~n~n" expr)
-     expr]))
+     (replace-ints-expr* expr)]
+    [_ expr]))
   ;(printf "  RESULT: ~a~n" result)
   result)
 
@@ -85,19 +80,12 @@
 ; (datum->syntax GOAL (syntax->list (syntax/loc #'3 #'2)) GOAL
 
 
-(define (replace/list f stxs)
-  (printf "replace/list; stxs=~a~n" stxs) ; stxs is indeed a syntax object w/ the proper srcloc
-  ; the trouble seems to be in the recombination. QualName and X are keeping context, (QualName X) is not
-  (quasisyntax/loc stxs
-    ;#,(map f (syntax-e stxs))))
-    #,(map (lambda (stx)
-             (define sub (f stx))
-             (define new-stx (quasisyntax/loc stx #,sub))
-             ;(printf "in lambda; stx=~a~n" stx)
-             ;(printf "in lambda; (f stx)=~a~n" sub)
-             ;(printf "in lambda; will replace with=~a~n" new-stx)
-             new-stx)
-           (syntax-e stxs))))
+(define (replace/list f stxs)    
+  ;(quasisyntax/loc stxs
+  ;  #,(map f (syntax-e stxs))))
+  (datum->syntax stxs
+                 (map f (syntax-e stxs))
+                 stxs))
 
 (define (replace-ints-expr* exprs)
   (replace/list replace-ints-expr exprs))

--- a/forge/lang/reader.rkt
+++ b/forge/lang/reader.rkt
@@ -11,6 +11,17 @@
 
 (do-time "forge/lang/reader")
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This series of functions intervenes at the pre-Forge-AST level to
+; insert automatic conversion between int-exprs and rel-exprs in
+; *some* cases; the others are handled in the AST construction.
+
+; Regarding syntax replacement, here and in the expander,
+; NOTE WELL this sentence from the Racket docs on syntax/loc: 
+; "The source location is adjusted only if the resulting syntax object
+; comes from the template itself rather than the value of a syntax pattern variable."
+; (In all other cases, we apparently must use datum->syntax.)
+
 (define (coerce-ints-to-atoms tree)
   ; AlloyModule: ModuleDecl? Import* Paragraph*
   (syntax-parse tree #:datum-literals (AlloyModule ModuleDecl Import)
@@ -31,8 +42,7 @@
 
 (define (replace-ints-expr expr)
   ;(printf "Replace-int-expr: ~a~n~n" expr)
-  (define result
-    (syntax-parse expr #:datum-literals (Name QualName Const Number)
+  (syntax-parse expr #:datum-literals (Name QualName Const Number)
     [(_ (Const (~optional "-") (Number n)))
      (quasisyntax/loc expr
        (Expr
@@ -40,22 +50,18 @@
                                  #,(quasisyntax/loc expr (QualName sing)))) "["
         #,(quasisyntax/loc expr (ExprList #,expr)) "]"))]
     [(_ (~or (Name (~literal sing))
-             (_ (QualName (~literal sing)))) "[" _ "]")
-     (printf "r-i-e base case: ~a~n" expr)
+             (_ (QualName (~literal sing)))) "[" _ "]")     
      expr]
     [(_ expr1 (~optional neg-tok) (CompareOp "<=") expr2)
      expr]
     [(parts ...)
      (replace-ints-expr* expr)]
     [_ expr]))
-  ;(printf "  RESULT: ~a~n" result)
-  result)
 
 (define (replace-ints-paragraph paragraph)
   ;(printf "Replace-ints-paragraph ~a~n~n" paragraph)
-  ; InstDecl : /INST-TOK Name Bounds Scope?
-  (define result
-    (syntax-parse paragraph #:datum-literals (IntsDecl Bounds)
+  ; InstDecl : /INST-TOK Name Bounds Scope?  
+  (syntax-parse paragraph #:datum-literals (IntsDecl Bounds)
     [(InstDecl name 
                (Bounds (~optional (~and "exactly" exactly-tok))
                        exprs ...)
@@ -66,23 +72,12 @@
                  #,(quasisyntax/loc paragraph (Bounds (~? exactly-tok) updated-exprs ...))
                  (~? scope)))]
     [(_ ...) paragraph]))
-;  (printf "    Result: ~a~n" result)
-  result)
 
-; NOTE: this (in repl): (quasisyntax/loc #'5 #,(syntax/loc #'3 #'2))
-; produces a #'2 with the loc of the #'3, not the location of the #'5
-; This doesn't work either:
-; (with-syntax ([foo (syntax/loc #'3 #'2)]) (quasisyntax/loc #'5 foo))
-; "The source location is adjusted only if the resulting syntax object
-; comes from the template itself rather than the value of a syntax pattern variable.
-; This seems to work:
-; (define GOAL #'5)
-; (datum->syntax GOAL (syntax->list (syntax/loc #'3 #'2)) GOAL
-
-
-(define (replace/list f stxs)    
+(define (replace/list f stxs)
+  ; Using quasisyntax/loc like this will NOT properly replace the syntax-location.
   ;(quasisyntax/loc stxs
   ;  #,(map f (syntax-e stxs))))
+  ; Instead, need to reconstruct the syntax object via datum->syntax
   (datum->syntax stxs
                  (map f (syntax-e stxs))
                  stxs))
@@ -93,6 +88,10 @@
 (define (replace-ints-paragraph* parags)
   (replace/list replace-ints-paragraph parags))
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Forge's reader function
 (define (read-syntax path port)
   (define this-lang 'forge)
   (define-values (logging-on? project email) (log:setup this-lang port path))
@@ -140,6 +139,6 @@
   ; (printf "Ints-coerced: ~a~n" ints-coerced)
   ; (raise "STOP")
   (define result (datum->syntax #f module-datum))
-  (printf "debug result of expansion: ~a~n" result)
+  ;(printf "debug result of expansion: ~a~n" result)
   result)
 

--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -43,12 +43,14 @@
 ; along with a list of all of the atom names for sig atoms.
 (define (send-to-kodkod run-spec run-command #:run-name [run-name (gensym)])
   (do-time "send-to-kodkod")
+  
   ; In case of error, highlight an AST node if able. Otherwise, focus on the offending run command.
   (define (raise-run-error message [node #f])
     (if node
         (raise-syntax-error #f message
                             (datum->syntax #f (build-source-location-syntax (nodeinfo-loc (node-info node)))))
         (raise-syntax-error #f message run-command)))
+  
   (when (member run-name (unbox run-name-history))
     (raise-run-error (format "Run name ~a was re-used; please use a different run name.~n" run-name)))
   (set-box! run-name-history (cons run-name (unbox run-name-history)))
@@ -503,7 +505,8 @@
       (apply append (map fill-lower-by-bound (get-children run-spec sig))))
     (define curr-lower (get-bound-lower sig))
     (when (and (not curr-lower) (Sig-one sig))
-      (raise-run-error (format "Instance block named members for an ancestor of 'one' sig ~a but no member name was given for ~a. This can result in inconsistency; please give bounds for ~a." (Sig-name sig) (Sig-name sig) (Sig-name sig))))
+      (raise-run-error (format "Instance block named members for an ancestor of 'one' sig ~a but no member name was given for ~a. This can result in inconsistency; please give bounds for ~a." (Sig-name sig) (Sig-name sig) (Sig-name sig))
+                       sig)) ; provide 2nd argument in order to localize
     (define true-lower
       (remove-duplicates
         (append children-lowers

--- a/forge/sigs-functional.rkt
+++ b/forge/sigs-functional.rkt
@@ -239,6 +239,16 @@
 ; a nominal bitwidth. Since we're speaking of sig cardinalities, assume this suffices.
 (define SUFFICIENT-INT-BOUND 8)
 
+; Helper to update provenance information within a Bound struct
+(define (new-orig-nodes bound the-relation bind)
+  (cond
+    [(not bind) (Bound-orig-nodes bound)]
+    [(hash-has-key? (Bound-orig-nodes bound) the-relation)
+     (hash-set (Bound-orig-nodes bound) the-relation
+               (cons bind (hash-ref (Bound-orig-nodes bound) the-relation)))]
+    [else (hash-set (Bound-orig-nodes bound) the-relation (list bind))]))
+
+
 ; Functionally update "scope" and "bound" based on this "bind" declaration
 (define/contract (do-bind bind scope bound)
   (-> (or/c node/formula? node/breaking/op? Inst?)
@@ -282,7 +292,8 @@
     ; Add the atom before evaluation, so that (atom ...) will be consistent with non-piecewise bounds.
     (define the-tuples (safe-fast-eval-exp (ast:-> the-atom the-rhs-expr) (Bound-tbindings bound) SUFFICIENT-INT-BOUND #f))
     (define the-atom-evaluated (first (first (safe-fast-eval-exp the-atom (Bound-tbindings bound) SUFFICIENT-INT-BOUND #f))))
-        
+    
+    (printf "TESTING: new-orig-nodes: ~a: ~a~n" the-relation (new-orig-nodes bound the-relation bind))
     (cond [(hash-has-key? piecewise-binds the-relation)
            (define former-pwb (hash-ref piecewise-binds the-relation))
            (unless (equal? op (PiecewiseBound-operator former-pwb))
@@ -294,10 +305,12 @@
            
            (define new-tuples (append (PiecewiseBound-tuples former-pwb) the-tuples))
            (Bound (Bound-pbindings bound) (Bound-tbindings bound)
-                  (hash-set piecewise-binds the-relation (PiecewiseBound new-tuples (cons the-atom-evaluated (PiecewiseBound-atoms former-pwb)) op)))]
+                  (hash-set piecewise-binds the-relation (PiecewiseBound new-tuples (cons the-atom-evaluated (PiecewiseBound-atoms former-pwb)) op))
+                  (new-orig-nodes bound the-relation bind))]
           [else
            (Bound (Bound-pbindings bound) (Bound-tbindings bound)
-                  (hash-set piecewise-binds the-relation (PiecewiseBound the-tuples (list the-atom-evaluated) op)))]))
+                  (hash-set piecewise-binds the-relation (PiecewiseBound the-tuples (list the-atom-evaluated) op))
+                  (new-orig-nodes bound the-relation bind))]))
   
   (match bind
     
@@ -379,7 +392,7 @@
      (cond [(node/expr/relation? left)
             (let ([tups (safe-fast-eval-exp right (Bound-tbindings bound) SUFFICIENT-INT-BOUND #f)])
               (define new-scope scope)
-              (define new-bound (update-bindings bound left tups tups))
+              (define new-bound (update-bindings bound left tups tups #:node bind))
               (values new-scope new-bound))]
            [(and (node/expr/op/join? left)
                  (list? (node/expr/op-children left))
@@ -404,7 +417,7 @@
        ; rel in expr
        [(node/expr/relation? left)
         (let ([tups (safe-fast-eval-exp right (Bound-tbindings bound) SUFFICIENT-INT-BOUND #f)])
-          (define new-bound (update-bindings bound left (@set) tups))
+          (define new-bound (update-bindings bound left (@set) tups #:node bind))
           (values scope new-bound))]
        ; atom.rel in expr
        [(and (node/expr/op/join? left)
@@ -420,7 +433,7 @@
        ; rel ni expr
        [(node/expr/relation? right)
         (let ([tups (safe-fast-eval-exp left (Bound-tbindings bound) SUFFICIENT-INT-BOUND #f)])
-          (define new-bound (update-bindings bound right tups))
+          (define new-bound (update-bindings bound right tups #:node bind))
           (values scope new-bound))]
        ; atom.rel ni expr
        [(and (node/expr/op/join? right)
@@ -570,6 +583,7 @@
       (Bound (hash)
              (hash Int (map list ints)
                    succ succs)
+             (hash)
              (hash))))
 
   (define/contract wrapped-bounds-inst Inst?
@@ -599,13 +613,13 @@
       (define tups (PiecewiseBound-tuples pwb))
       (cond [(equal? '= (PiecewiseBound-operator pwb))
              ; update only lower bound, not upper (handled in send-to-kodkod)
-             (update-bindings bs rel tups #f)] 
+             (update-bindings bs rel tups #f #:node #f)] 
             [(equal? 'in (PiecewiseBound-operator pwb))
              ; do nothing (upper bound handled in send-to-kodkod)
              bs]
             [(equal? 'ni (PiecewiseBound-operator pwb))
              ; update lower-bound
-             (update-bindings bs rel tups #f)]
+             (update-bindings bs rel tups #f #:node #f)]
             [else 
              (raise (error (format "unsupported comparison operator; got ~a, expected =, ni, or in" (PiecewiseBound-operator pwb))))])))
      
@@ -943,13 +957,22 @@
 ; Updates the partial binding for a given sig or relation.
 ; If a binding already exists, takes the intersection.
 ; If this results in an exact bound, adds it to the total bounds.
-(define (update-bindings bound rel lower [upper #f])
+(define (update-bindings bound rel lower [upper #f] #:node [node #f])
 
   (when (>= (get-verbosity) VERBOSITY_HIGH)
     (printf "  update-bindings for ~a; |lower|=~a; |upper|=~a~n"
             rel (if lower (set-count (list->set lower)) #f) 
                 (if upper (set-count (list->set upper)) #f)))
 
+  ; In case of error, highlight an AST node if able. Otherwise, focus on the offending run command.
+  (define (raise-run-error message node)
+        (raise-syntax-error #f message
+                            (datum->syntax #f (build-source-location-syntax (nodeinfo-loc (node-info node))))))
+  ; Produce a single AST node to blame for a given relation's bound, or #f if none available
+  (define (get-blame-node the-rel)
+    (define result (hash-ref (Bound-orig-nodes bound) the-rel #f))
+    (and result (first result)))
+  
   (unless lower
     (raise (error (format "Error: update-bindings for ~a expected a lower bound, got #f." rel))))  
   (set! lower (list->set lower))
@@ -967,8 +990,9 @@
                         [else (or upper (sbound-upper old))]))))
   
   (unless (or (not upper) (subset? lower upper))
-    (raise (format "Bound conflict: upper bound on sig or field ~a was not a superset of lower bound. Lower=~a; Upper=~a." 
-                   rel lower upper)))
+    (raise-run-error (format "Bound conflict: upper bound on sig or field ~a was not a superset of lower bound. Lower=~a; Upper=~a." 
+                             rel lower upper)
+                     (get-blame-node rel)))
   
   (define new-pbindings
     (hash-set old-pbindings rel (sbound rel lower upper)))
@@ -978,9 +1002,12 @@
     (if (equal? lower upper) 
         (hash-set old-tbindings rel (set->list lower))
         old-tbindings))
-
+  
+  (printf "TESTING: new-orig-nodes(update-bindings): ~a: ~a~n" rel (new-orig-nodes bound rel node))
+  
   ; Functionally update; piecewise bounds are out of scope so keep them the same.
-  (define new-bound (Bound new-pbindings new-tbindings (Bound-piecewise bound)))  
+  ; Likewise, original AST nodes haven't changed
+  (define new-bound (Bound new-pbindings new-tbindings (Bound-piecewise bound) (new-orig-nodes bound rel node)))  
   new-bound)
 
 ; state-set-option :: State, Symbol, Symbol -> State

--- a/forge/sigs-functional.rkt
+++ b/forge/sigs-functional.rkt
@@ -969,8 +969,8 @@
             rel (if lower (set-count (list->set lower)) #f) 
                 (if upper (set-count (list->set upper)) #f)))
 
-  ; In case of error, highlight an AST node if able. Otherwise, focus on the offending run command.
-  (define (raise-run-error message node)
+  ; In case of error, highlight an AST node if able.
+  (define (raise-error message node)
         (raise-syntax-error #f message
                             (datum->syntax #f (build-source-location-syntax (nodeinfo-loc (node-info node))))))
   
@@ -991,7 +991,7 @@
                         [else (or upper (sbound-upper old))]))))
   
   (unless (or (not upper) (subset? lower upper))
-    (raise-run-error (format "Bound conflict: upper bound on sig or field ~a was not a superset of lower bound. Lower=~a; Upper=~a." 
+    (raise-error (format "Bound conflict: upper bound on sig or field ~a was not a superset of lower bound. Lower=~a; Upper=~a." 
                              rel lower upper)
                      (get-blame-node bound rel)))
   

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -124,6 +124,8 @@
   [tbindings (hash/c node/expr/relation? any/c)]
   ; incomplete bindings for a given relation, indexed by first column
   [piecewise PiecewiseBounds/c]
+  ; original AST nodes, for improving errors, indexed by relation
+  [orig-nodes (hash/c node/expr/relation? (listof node?))]
   ) #:transparent)
                                 
 ; An Inst function is an accumulator of bounds information. It doesn't (necessarily)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -580,10 +580,10 @@
   (syntax-case stx ()
     [(test name args ... #:expect expected)  
      (add-to-execs
-       (syntax/loc stx 
+       (quasisyntax/loc stx 
          (cond 
           [(member 'expected '(sat unsat))           
-           (run name args ...)
+           #,(syntax/loc stx (run name args ...))
            (define first-instance (tree:get-value (Run-result name)))
            (unless (equal? (if (Sat? first-instance) 'sat 'unsat) 'expected)
              (when (> (get-verbosity) 0)

--- a/forge/tests/error/inst-lower-not-subset-upper.frg
+++ b/forge/tests/error/inst-lower-not-subset-upper.frg
@@ -1,0 +1,13 @@
+#lang forge
+option run_sterling off
+option verbose 0 
+
+sig Node {edges: set Node}
+
+test expect {
+    shouldFailWithError: {} for {  
+        Node in `N0 + `N1 + `N2
+        Node ni `N3
+    } 
+    is sat
+}

--- a/forge/tests/error/inst-undefined-bound-child-one.frg
+++ b/forge/tests/error/inst-undefined-bound-child-one.frg
@@ -13,4 +13,7 @@ test expect {
     shouldFailWithError: {one A and one B}     
     for { Parent = `A + `B } 
     is sat
+
+    -- TODO: syntax loc should be the _use_ location, not the _decl_ location of A or B
+    -- TODO: in: () is confusing
 }

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -99,6 +99,7 @@
     
     (list "ill_typed_inst_columns_reversed.frg" #rx"age")
     (list "inst-undefined-bound-child-one.frg" #rx"for an ancestor of")
+    (list "inst-lower-not-subset-upper.frg" #rx"was not a superset")
     (list "invalid-example.frg" #rx"Invalid example 'onlyBabies'")
 
     (list "no-temporal-ltl.frg" #rx"use of LTL operator without temporal problem_type")

--- a/forge/tests/error/piecewise-bind-mix-ops.frg
+++ b/forge/tests/error/piecewise-bind-mix-ops.frg
@@ -1,4 +1,5 @@
-#lang forge/bsl
+#lang forge
+// /bsl
 option verbose 0
 
 abstract sig Player {}


### PR DESCRIPTION
Enabling errors in bounds to report location:
![image](https://github.com/tnelson/Forge/assets/318880/473d485e-afbd-43e7-8421-c3956c9a45f8)

Major reminder, which I have also put in a comment in `reader.rkt`: 

> Regarding syntax replacement, here and in the expander,
> NOTE WELL this sentence from the Racket docs on syntax/loc: 
> "The source location is adjusted only if the resulting syntax object
> comes from the template itself rather than the value of a syntax pattern variable."
> (In all other cases, we apparently must use datum->syntax.)

Another reminder: anywhere we have a macro that expands to another macro within some other syntax, we need to re-assert the syntax-location information for that inner macro. E.g., a `test` expands to several things, including a `run`. If we just write that as:

```
(run name args ...)
```

the `run` syntax-expression will take the syntax-location of the module the macro is defined in (in this case, `sigs.rkt`). Instead, do this, within a `quasisyntax/loc`: 

```
#,(syntax/loc stx (run name args ...))
```


