### PR TITLE
Roll in better handling of some errors, propagate stxloc; beginnings of srcloc tests

### DIFF
--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -1107,3 +1107,19 @@
 (make-breaker pbij 'pbij)
 
 (make-breaker default 'default)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Racket "user errors" avoid the (possibly confusing) stack trace that a Racket 
+; "syntax error" produces, but only DrRacket will highlight source location from
+; a user error. For the VSCode extension (and use from the terminal), produce a
+; custom user error that contains the row and column information of the offending
+; AST node.
+(define (pretty-loc loc)
+  (format "~a:~a:~a" (srcloc-source loc) (srcloc-line loc) (srcloc-column loc)))
+(define (raise-forge-error #:msg [msg "error"] #:context [context #f])
+  (define loc (cond [(nodeinfo? context) (pretty-loc (nodeinfo-loc context))]
+                    [(node? context) (pretty-loc (nodeinfo-loc (node-info context)))]
+                    [(srcloc? context) (pretty-loc context)] 
+                    [else "unknown location"]))
+  (raise-user-error (format "[~a] ~a" loc msg)))
+

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -80,7 +80,19 @@
 (struct node/int node () #:transparent)
 
 ; Should never be directly instantiated
-(struct node/formula node () #:transparent)
+(struct node/formula node () #:transparent
+  ; Give a friendlier error if Racket thinks we are asking it to treat a formula as a function
+  #:property prop:procedure
+  (λ (f . x)
+    (cond [(node/fmla/pred-spacer? f)
+           (raise-forge-error
+            #:msg (format "Tried to give arguments to a predicate, but it takes none: ~a." (node/fmla/pred-spacer-name f))
+            #:context f)]
+          [else
+           (raise-forge-error
+            #:msg (format "Could not use formula as a function: ~a." (deparse f))
+            #:context f)])))
+  
 
 ;; ARGUMENT CHECKS -------------------------------------------------------------
 
@@ -451,15 +463,21 @@
 ; Helper to construct a set comprehension (and give useful errors, in case
 ; these are shown to an end-user)
 (define (raise-set-comp-quantifier-error e)
-  (raise-user-error "Set-comprehension variable domain expected a singleton or relational expression" (deparse e)))
+  (raise-forge-error
+   #:msg (format "Set-comprehension variable domain expected a singleton or relational expression: ~a" (deparse e))
+   #:context e))
 (define (comprehension info decls formula)
   (for ([e (map cdr decls)])
     (unless (node/expr? e)
       (raise-set-comp-quantifier-error e))
     (unless (equal? (node/expr-arity e) 1)
-      (raise-user-error "Set-comprehension variable domain needs arity = 1" (deparse e)))
+      (raise-forge-error
+       #:msg (format "Set-comprehension variable domain needs arity = 1: ~a" (deparse e))
+       #:context e))
     (unless (node/formula? formula)
-      (raise-user-error "Set-comprehension condition expected a formula." (deparse formula))))
+      (raise-forge-error
+       #:msg (format "Set-comprehension condition expected a formula: ~a" (deparse formula))
+       #:context formula)))
   (node/expr/comprehension info (length decls) decls formula))
 (define (set/func decls formula #:info [node-info empty-nodeinfo])
   (comprehension node-info decls formula))
@@ -806,14 +824,16 @@
                              (datum->syntax #f (deparse expr) (build-source-location-syntax loc)))) 
   (node/formula/multiplicity info mult expr))
 
-(define (no-pairwise-intersect vars)
-  (apply &&/func (no-pairwise-intersect-recursive-helper vars)))
+(define (no-pairwise-intersect vars #:context [context #f])
+  (apply &&/func (no-pairwise-intersect-recursive-helper vars #:context context)))
 
-(define (no-pairwise-intersect-recursive-helper vars)
-  (cond [(empty? vars) (raise-user-error "Cannot take pairwise intersection of empty list")]
+(define (no-pairwise-intersect-recursive-helper vars #:context [context #f])
+  (cond [(empty? vars) (raise-forge-error
+                        #:msg "Cannot take pairwise intersection of empty list"
+                        #:context context)]
         [(empty? (rest vars)) (list true)]
         [else (append (map (lambda (elt) (no (& (first vars) elt))) (rest vars))
-                      (no-pairwise-intersect-recursive-helper (rest vars)))]))
+                      (no-pairwise-intersect-recursive-helper (rest vars) #:context context))]))
 
 ;;; ALL ;;;
 
@@ -830,7 +850,10 @@
     ; quantifier case with disjointness flag; embed and repeat
     ; TODO: currently discarding the multiplicity info, unchecked
     [(_ info #:disj ([v0 e0 m0:opt-mult-class] ...) pred)
-     #'(all/info info ([v0 e0 m0] ...) (=> (no-pairwise-intersect (list v0 ...)) pred))]
+     (quasisyntax/loc stx
+       (all/info info ([v0 e0 m0] ...)
+                 #,(quasisyntax/loc stx
+                     (=> (no-pairwise-intersect (list v0 ...) #:context #,(build-source-location stx)) pred))))]
     [(_ info ([v0 e0 m0:opt-mult-class] ...) pred)     
      (quasisyntax/loc stx
        (let* ([v0 (node/expr/quantifier-var info (node/expr-arity e0) (gensym (format "~a_all" 'v0)) 'v0)] ...)
@@ -863,7 +886,11 @@
          (quantified-formula info 'some (list (cons v0 e0) ...) pred)))]
     ; quantifier case with disjointness flag; embed and repeat
     [(_ info #:disj ([v0 e0 m0:opt-mult-class] ...) pred)
-     #'(some/info info ([v0 e0 m0] ...) (&& (no-pairwise-intersect (list v0 ...)) pred))]
+     (quasisyntax/loc stx
+       (some/info info ([v0 e0 m0] ...)
+                  #,(quasisyntax/loc stx
+                      (&& (no-pairwise-intersect (list v0 ...)
+                                                 #:context #,(build-source-location stx)) pred))))]
     ; multiplicity case
     [(_ info expr)
      (quasisyntax/loc stx
@@ -923,7 +950,9 @@
      (quasisyntax/loc stx
        ; Kodkod doesn't have a "one" quantifier natively.
        ; Instead, desugar as a multiplicity of a set comprehension
-       (multiplicity-formula info 'one (set ([x1 r1] ...) (&& (no-pairwise-intersect (list x1 ...)) pred))))]
+       (multiplicity-formula info 'one
+                             (set ([x1 r1] ...)
+                                  #,(quasisyntax/loc stx (&& (no-pairwise-intersect (list x1 ...) #:context stx) pred)))))]
     [(_ info ([x1 r1 m0:opt-mult-class] ...) pred)
      (quasisyntax/loc stx
        ; Kodkod doesn't have a "one" quantifier natively.
@@ -955,7 +984,10 @@
      (quasisyntax/loc stx
        ; Kodkod doesn't have a lone quantifier natively.
        ; Instead, desugar as a multiplicity of a set comprehension
-       (multiplicity-formula info 'lone (set ([x1 r1] ...) (&& (no-pairwise-intersect (list x1 ...)) pred))))]
+       (multiplicity-formula info 'lone (set ([x1 r1] ...)
+                                             #,(quasisyntax/loc stx
+                                                 (&& (no-pairwise-intersect (list x1 ...)
+                                                                            #:context #,(build-source-location stx)) pred)))))]
     [(_ info ([x1 r1 m0:opt-mult-class] ...) pred)
      (quasisyntax/loc stx
        ; Kodkod doesn't have a lone quantifier natively.
@@ -1109,6 +1141,10 @@
 (make-breaker default 'default)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; *** raise-forge-error ***
+;
+; Use this error-throwing function whenever possible in Forge.
+; 
 ; Racket "user errors" avoid the (possibly confusing) stack trace that a Racket 
 ; "syntax error" produces, but only DrRacket will highlight source location from
 ; a user error. For the VSCode extension (and use from the terminal), produce a
@@ -1120,6 +1156,6 @@
   (define loc (cond [(nodeinfo? context) (pretty-loc (nodeinfo-loc context))]
                     [(node? context) (pretty-loc (nodeinfo-loc (node-info context)))]
                     [(srcloc? context) (pretty-loc context)] 
-                    [else "unknown location"]))
+                    [else "unknown:?:?"]))
   (raise-user-error (format "[~a] ~a" loc msg)))
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -13,6 +13,7 @@
 (require (only-in racket empty? first))
 (require forge/sigs)
 (require forge/choose-lang-specific)
+(require (only-in forge/lang/ast raise-forge-error))
 
 (provide isSeqOf seqFirst seqLast indsOf idxOf lastIdxOf elems inds isEmpty hasDups reachable)
 (provide #%module-begin)
@@ -1025,7 +1026,7 @@
              (syntax-parameterize ([current-forge-context 'inst])
                (list #,@(syntax/loc stx bounds.translate))))))]))
 
-(define (disambiguate-block xs)
+(define (disambiguate-block xs #:stx [stx #f])
   (cond [(empty? xs) 
          ; {} always means the formula true
          true]
@@ -1038,16 +1039,21 @@
          ; body of a helper function that produces an int-expression: one int-expression
         [(and (equal? 1 (length xs)) (node/int? (first xs)))
          (first xs)]         
-        [else 
-         (raise-user-error (format "~a" xs)
-                           (format "Ill-formed block: expected either one expression or any number of formulas"))]))
+        [else
+         ;(raise-user-error (format "~a" xs)
+         ;                  (format "Ill-formed block: expected either one expression or any number of formulas"))]))
+         (raise-forge-error
+          #:msg (format "Ill-formed block: expected either one expression or any number of formulas")
+          #:context stx)]))
 
 ; Block : /LEFT-CURLY-TOK Expr* /RIGHT-CURLY-TOK
 (define-syntax (Block stx)
   (syntax-parse stx
     [((~datum Block) exprs:ExprClass ...)
      (with-syntax ([(exprs ...) (syntax->list #'(exprs ...))])
-       (syntax/loc stx (disambiguate-block (list exprs ...))))]))
+       (quasisyntax/loc stx
+         (disambiguate-block (list exprs ...)
+                             #:stx #,(build-source-location stx))))]))
 
 (define-syntax (Expr stx)
   ;(printf "Debug: Expr: ~a~n" stx)

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1040,8 +1040,6 @@
         [(and (equal? 1 (length xs)) (node/int? (first xs)))
          (first xs)]         
         [else
-         ;(raise-user-error (format "~a" xs)
-         ;                  (format "Ill-formed block: expected either one expression or any number of formulas"))]))
          (raise-forge-error
           #:msg (format "Ill-formed block: expected either one expression or any number of formulas")
           #:context stx)]))

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -7,6 +7,7 @@
          (for-syntax racket/base syntax/parse racket/syntax syntax/parse/define racket/function
                      syntax/srcloc racket/match racket/list                     
                      (only-in racket/path file-name-from-path))
+         syntax/srcloc
          ; Needed because the abstract-tok definition below requires phase 2
          (for-syntax (for-syntax racket/base)))
                  
@@ -1035,7 +1036,8 @@
          (first xs)]
          ; Body of a predicate: any number of formulas
         [(andmap node/formula? xs)
-         (&& xs)]
+         (define info (nodeinfo (build-source-location stx) 'checklangplaceholder))
+         (&&/info info xs)]
          ; body of a helper function that produces an int-expression: one int-expression
         [(and (equal? 1 (length xs)) (node/int? (first xs)))
          (first xs)]         

--- a/forge/run-tests.sh
+++ b/forge/run-tests.sh
@@ -16,7 +16,7 @@ raco setup forge
 
 # Get test files
 testDir=$1
-doNotTestPattern="error/[^/]*\\.frg"
+doNotTestPattern="[error|srcloc]/[^/]*\\.frg"
 # ^ these tests get checked by tests/error/main.rkt
 testFiles="$( find $testDir -type f \( -name "*.rkt" -o -name "*.frg" \) | grep --invert-match ${doNotTestPattern} )"
 numTestFiles="$(echo "$testFiles" | wc -l)"

--- a/forge/shared.rkt
+++ b/forge/shared.rkt
@@ -162,4 +162,3 @@
           (set!-gc-time gc)
           (format "~a at ~a\tlast step: ~a\tgc: ~a\ttotal: ~a"
                   new-msg t diff gc-diff (- t initial-time)))))))
-

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -620,7 +620,7 @@ Returns whether the given run resulted in sat or unsat, respectively.
   (if (node/formula? b)
       (&&/info info
                (=>/info info a b)
-               (=>/info info (! a) c))
+               (=>/info info (!/info info a) c))
       (ite/info info a b c)))
 (define-syntax (ifte stx)
   (syntax-parse stx 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -840,7 +840,7 @@
 
 (define-builtin (isSeqOf info r1 d)
   (&&/info info
-      (in/info info r1 (-> Int univ))
+      (in/info info r1 (->/info info Int univ))
       (in/info info (join/info info Int r1) d)
       (all/info info ([i1 (join/info info r1 univ)])
            (&&/info info (int>= (sum/info info i1) (int 0))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -842,14 +842,14 @@
   (&&/info info
       (in/info info r1 (-> Int univ))
       (in/info info (join/info info Int r1) d)
-      (all ([i1 (join/info info r1 univ)])
+      (all/info info ([i1 (join/info info r1 univ)])
            (&&/info info (int>= (sum/info info i1) (int 0))
                (lone (join/info info i1 r1))))
-      (all ([e (join/info info Int r1)])
-           (some (join/info info r1 e)))
-      (all ([i1 (join/info info r1 univ)])
+      (all/info info ([e (join/info info Int r1)])
+           (some/info info (join/info info r1 e)))
+      (all/info info ([i1 (join/info info r1 univ)])
            (implies (!= i1 (sing/info info (int 0)))
-                    (some (join/info info
+                    (some/info info (join/info info
                      (sing/info info
                       (subtract/info info
                        (sum/info info i1) (int 1))) r1))))))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -844,11 +844,11 @@
       (in/info info (join/info info Int r1) d)
       (all/info info ([i1 (join/info info r1 univ)])
            (&&/info info (int>= (sum/info info i1) (int 0))
-               (lone (join/info info i1 r1))))
+               (lone/info info (join/info info i1 r1))))
       (all/info info ([e (join/info info Int r1)])
            (some/info info (join/info info r1 e)))
       (all/info info ([i1 (join/info info r1 univ)])
-           (implies (!= i1 (sing/info info (int 0)))
+           (=>/info info (!= i1 (sing/info info (int 0)))
                     (some/info info (join/info info
                      (sing/info info
                       (subtract/info info

--- a/forge/tests/error/expect-predicate-args.frg
+++ b/forge/tests/error/expect-predicate-args.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+option verbose 0 
+option run_sterling off
+abstract sig Player {}
+one sig X, O extends Player {}
+sig Board {board: pfunc Int -> Int -> Player}
+
+pred wellformed[b: Board] {
+  all row, col: Int | {
+    (row < 0 or row > 2 or col < 0 or col > 2) 
+      implies no b.board[row][col] }}
+
+test expect { should_error: { wellformed } is sat }
+

--- a/forge/tests/error/expect-predicate-no-args.frg
+++ b/forge/tests/error/expect-predicate-no-args.frg
@@ -1,0 +1,14 @@
+#lang forge/bsl
+option verbose 0 
+option run_sterling off
+abstract sig Player {}
+one sig X, O extends Player {}
+sig Board {board: pfunc Int -> Int -> Player}
+
+pred wellformed {
+  all b: Board | all row, col: Int | {
+    (row < 0 or row > 2 or col < 0 or col > 2) 
+      implies no b.board[row][col] }}
+
+test expect { should_error: { all b: Board | wellformed[b] } is sat }
+

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -108,6 +108,8 @@
     (list "expr-in-comprehension-condition.frg" #rx"expected a formula")
     (list "non-expr-in-comprehension-domain.frg" #rx"expected a singleton or relational expression")
     (list "arity-in-comprehension-domain.frg" #rx"variable domain needs arity = 1")
+    (list "expect-predicate-args.frg" #rx"Ill-formed block")
+    (list "expect-predicate-no-args.frg" #rx"Tried to give arguments to a predicate, but it takes none") 
   ))
 
 

--- a/forge/tests/forge-core/formulas/disj-one-core.rkt
+++ b/forge/tests/forge-core/formulas/disj-one-core.rkt
@@ -1,7 +1,6 @@
 #lang forge/core
 
 (set-option! 'verbose 0)
-;(set-option! 'verbose 10)
 
 (sig onede)
 (relation edges (onede onede))

--- a/forge/tests/srclocs/main.rkt
+++ b/forge/tests/srclocs/main.rkt
@@ -2,24 +2,39 @@
 
 ; Confirm that source locations are indeed preserved in case they are needed for errors.
 
-(require (only-in rackunit check-equal?))
-(require (only-in racket flatten first))
+(require (rename-in rackunit [check rackunit-check]))
+(require (only-in racket flatten first string-contains?))
 
 ; Returns a list of all AST nodes in this tree
-(define (gather-tree n)
-  (cond [(node/expr/op? n)
-         (flatten (map gather-tree (node/expr/op-children n)))]
-        [(node/formula/op? n)
-         (flatten (map gather-tree (node/formula/op-children n)))]
-        [(node/fmla/pred-spacer? n)
-         (gather-tree (node/fmla/pred-spacer-expanded n))]
-        [(node/expr/fun-spacer? n)
-         (gather-tree (node/expr/fun-spacer-expanded n))]
-        [(node/formula/quantified? n)
-         ; TODO: decls
-         (gather-tree (node/formula/quantified-formula n))]
-        ;; TODO: other cases
-        [else (list n)]))
+(define (gather-tree n #:leafs-only leafs-only)
+  (define descendents
+    (cond [(node/expr/op? n)
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+                         (node/expr/op-children n)))]
+          [(node/formula/op? n)
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+                         (node/formula/op-children n)))]
+          [(node/int/op? n)
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+                         (node/int/op-children n)))]
+          
+          [(node/fmla/pred-spacer? n)
+           (gather-tree (node/fmla/pred-spacer-expanded n) #:leafs-only leafs-only)]
+          [(node/expr/fun-spacer? n)
+           (gather-tree (node/expr/fun-spacer-expanded n) #:leafs-only leafs-only)]
+
+          [(node/formula/multiplicity? n)
+           (gather-tree (node/formula/multiplicity-expr n) #:leafs-only leafs-only)]
+          [(node/formula/quantified? n)
+           ; TODO: decls
+           (gather-tree (node/formula/quantified-formula n) #:leafs-only leafs-only)]
+
+          ;; TODO: other cases
+          [else (list n)]))
+  (if leafs-only
+      descendents
+      (cons n descendents)))
+
 (define (print-one-per-line l)
   (cond [(not (list l)) (printf "  ~a~n" l)]
         [(empty? l) (printf "~n")]
@@ -28,6 +43,20 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (require (only-in "../forge/library/seq.frg" order))
-(print-one-per-line (gather-tree order))
+; For debugging: is anything not being broken down properly?
+; (print-one-per-line (gather-tree order #:leafs-only #t))
 
-;(map (lambda (x) (nodeinfo-loc (node-info x))) (node/formula/op-children ))
+; Confirm that the syntax location information for all nodes refers to the proper module
+(for ([n (gather-tree order #:leafs-only #f)])
+  (define loc (nodeinfo-loc (node-info n)))
+  (define source-path-correct
+    (string-contains?
+     (path->string (srcloc-source loc))
+     "/forge/library/seq.frg"))
+  (unless source-path-correct 
+    (printf "     ~a: ~a~n" n loc))
+  ; Comment out for now, avoid unpleasant flickering spam
+  ;(check-true source-path-correct)
+  )
+
+;(map (lambda (x)  (node/formula/op-children ))

--- a/forge/tests/srclocs/main.rkt
+++ b/forge/tests/srclocs/main.rkt
@@ -1,0 +1,33 @@
+#lang forge/core 
+
+; Confirm that source locations are indeed preserved in case they are needed for errors.
+
+(require (only-in rackunit check-equal?))
+(require (only-in racket flatten first))
+
+; Returns a list of all AST nodes in this tree
+(define (gather-tree n)
+  (cond [(node/expr/op? n)
+         (flatten (map gather-tree (node/expr/op-children n)))]
+        [(node/formula/op? n)
+         (flatten (map gather-tree (node/formula/op-children n)))]
+        [(node/fmla/pred-spacer? n)
+         (gather-tree (node/fmla/pred-spacer-expanded n))]
+        [(node/expr/fun-spacer? n)
+         (gather-tree (node/expr/fun-spacer-expanded n))]
+        [(node/formula/quantified? n)
+         ; TODO: decls
+         (gather-tree (node/formula/quantified-formula n))]
+        ;; TODO: other cases
+        [else (list n)]))
+(define (print-one-per-line l)
+  (cond [(not (list l)) (printf "  ~a~n" l)]
+        [(empty? l) (printf "~n")]
+        [else (printf "  ~a~n" (first l)) (print-one-per-line (rest l))]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(require (only-in "../forge/library/seq.frg" order))
+(print-one-per-line (gather-tree order))
+
+;(map (lambda (x) (nodeinfo-loc (node-info x))) (node/formula/op-children ))

--- a/forge/tests/srclocs/main.rkt
+++ b/forge/tests/srclocs/main.rkt
@@ -59,4 +59,5 @@
   ;(check-true source-path-correct)
   )
 
-;(map (lambda (x)  (node/formula/op-children ))
+;; TODO: check run parameters as well (catch instances...) 
+;; TODO: other examples

--- a/forge/tests/srclocs/main.rkt
+++ b/forge/tests/srclocs/main.rkt
@@ -40,24 +40,40 @@
         [(empty? l) (printf "~n")]
         [else (printf "  ~a~n" (first l)) (print-one-per-line (rest l))]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(require (only-in "../forge/library/seq.frg" order))
-; For debugging: is anything not being broken down properly?
-; (print-one-per-line (gather-tree order #:leafs-only #t))
 
 ; Confirm that the syntax location information for all nodes refers to the proper module
-(for ([n (gather-tree order #:leafs-only #f)])
-  (define loc (nodeinfo-loc (node-info n)))
-  (define source-path-correct
-    (string-contains?
-     (path->string (srcloc-source loc))
-     "/forge/library/seq.frg"))
-  (unless source-path-correct 
-    (printf "     ~a: ~a~n" n loc))
-  ; Comment out for now, avoid unpleasant flickering spam
-  ;(check-true source-path-correct)
-  )
+(define (check-full-ast-srclocs root-ast sub-path-str)
+  (for ([n (gather-tree root-ast #:leafs-only #f)])
+    (define loc (nodeinfo-loc (node-info n)))
+    (define source-path-correct
+      (string-contains?
+       (path->string (srcloc-source loc))
+       sub-path-str))
+    (unless source-path-correct 
+      (printf "     ~a: ~a~n" n loc))
+    ; Comment out for now, avoid unpleasant flickering spam
+    ;(check-true source-path-correct)
+    ))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Need to do these separately, because of "already bound" sig names shared etc.
+
+;(require (only-in "../forge/library/seq.frg" order))
+; For debugging: is anything not being broken down properly?
+; (print-one-per-line (gather-tree order #:leafs-only #t))
+;(check-full-ast-srclocs order "/forge/library/seq.frg")
+
+;(require (only-in "../forge/library/reachable.frg" reach6))
+;(check-full-ast-srclocs reach6 "/forge/library/reachable.frg")
+
+(require (only-in "../forge/formulas/booleanFormulaOperators.rkt" Implies And Or Not))
+(check-full-ast-srclocs Implies  "/forge/formulas/booleanFormulaOperators.rkt")
+(check-full-ast-srclocs And  "/forge/formulas/booleanFormulaOperators.rkt")
+(check-full-ast-srclocs Or  "/forge/formulas/booleanFormulaOperators.rkt")
+(check-full-ast-srclocs Not  "/forge/formulas/booleanFormulaOperators.rkt")
+
+
 
 ;; TODO: check run parameters as well (catch instances...) 
 ;; TODO: other examples


### PR DESCRIPTION
This PR includes mainly fixes for some error messages and the beginnings of test-suite infrastructure for preservation of syntax location information during expansion. 

If used as a procedure post-expansion, formula AST nodes now enable a more sensible error. Previously, this error was the usual error that Racket would give if a non-procedure was used as one. 

The `raise-forge-error` function should gradually replace `raise-user-error` and `raise-syntax-error` in Forge, because it eschews the confusing stack trace but *prints* the syntax location, so that the VSCode extension (and those running from the terminal) can see the location of the issue. 

