### PR TITLE
Draft: Adding universal quantification to asserts

### DIFF
--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -95,7 +95,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
 
 ; For now, we only allow SINGLE quantification.
 ; As my racket skills get better, I will modify this to allow for multiple nested quantifications.
-QuantifiedPropertyDecl : /ASSERT-TOK ALL-TOK DISJ-TOK? QuantDecl BAR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
+QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK DISJ-TOK? QuantDecl /BAR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
 
 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -95,7 +95,7 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
-QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK QuantDeclList /BAR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
+QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK QuantDeclList /BAR-TOK Name (/LEFT-SQUARE-TOK NameList /RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (/LEFT-SQUARE-TOK NameList /RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
 
 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -49,6 +49,7 @@ Import : /OPEN-TOK QualName (LEFT-SQUARE-TOK QualNameList RIGHT-SQUARE-TOK)? (AS
           | InstDecl
           | ExampleDecl 
           | PropertyDecl
+          | QuantifiedPropertyDecl
           | TestSuiteDecl
 
 ; NOTE: When extending sigs with "in" (subset sigs) is implemented,
@@ -93,16 +94,15 @@ Typescope : EXACTLY-TOK? Number QualName
 Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
-; For now, we only allow SINGLE quantification.
-; As my racket skills get better, I will modify this to allow for multiple nested quantifications.
-QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK DISJ-TOK? QuantDecl /BAR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
+
+QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK QuantDeclList /BAR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
 
 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 
 
 TestSuiteDecl : /TEST-TOK /SUITE-TOK /FOR-TOK Name /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK
 
-@TestConstruct : ExampleDecl | TestExpectDecl | PropertyDecl
+@TestConstruct : ExampleDecl | TestExpectDecl | PropertyDecl | QuantifiedPropertyDecl
 
 
 # UnOp : Mult

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -94,6 +94,10 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
+PropertyDeclQuantification : Quant DISJ-TOK? QuantDeclList BlockOrBar
+QuantifiedPropertyDecl : /ASSERT-TOK PropertyDeclQuantification* Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
+
+
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 
 
 TestSuiteDecl : /TEST-TOK /SUITE-TOK /FOR-TOK Name /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -93,9 +93,9 @@ Typescope : EXACTLY-TOK? Number QualName
 Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
-
-PropertyDeclQuantification : Quant DISJ-TOK? QuantDeclList BlockOrBar
-QuantifiedPropertyDecl : /ASSERT-TOK PropertyDeclQuantification* Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
+; For now, we only allow SINGLE quantification.
+; As my racket skills get better, I will modify this to allow for multiple nested quantifications.
+QuantifiedPropertyDecl : /ASSERT-TOK ALL-TOK DISJ-TOK? QuantDecl BAR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (LEFT-SQUARE-TOK ExprList RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
 
 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -983,18 +983,10 @@
 (define-syntax (QuantifiedPropertyDecl stx)
   (syntax-parse stx
     [qpd:QuantifiedPropertyDeclClass  
-    #:do (printf "qpd ~s~n" (syntax->datum #'qpd)) 
-    #:do [(printf "qpd-pred-name ~s~n" (syntax->datum #'qpd.pred-name)) ]
-    #:do [(printf "qpd-pred-exprs: ~a\n" (syntax->datum #'qpd.pred-exprs))]
-    ;;#:do [(printf "cons : qpd-prop-exprs: ~a\n" (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs)))]
 
-
-
-    ;;; #'(cons (syntax->datum qpd.prop-name) (syntax->datum #'qpd.pred-exprs) )
+    ;;#:do [(printf "qpd-pred-name ~s~n" (syntax->datum #'qpd.pred-name)) ]
     ;;; Issues: Disj not supported I think.
-    ;;;         Also, pred-exprs and prop-exprs are not being expanded correctly.
-    ;;;         they are interpreted as joins when more than one name is in the list. 
-    ;;;         Need to understand how to do this right.
+
      
     ;; TODO: Need a more unique test name
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
@@ -1013,11 +1005,11 @@
                     ;; no prop instantiations, no pred instantiations.
                     (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name qpd.pred-name)))
                     ;; no prop instantiations, pred instantiations.
-                    (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name (qpd.pred-name qpd.pred-exprs)))))
+                    (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name (exp-pred-exprs ...)))))
                     
                     (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
                       ;; prop instantiations, no pred instantiations.
-                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs ) qpd.pred-name)))
+                      (syntax/loc stx (all  qpd.quant-decls (implies (exp-prop-exprs ...) qpd.pred-name)))
                       ;; prop instantiations, pred instantiations.
                       
                       (syntax/loc stx (all  qpd.quant-decls (implies (exp-prop-exprs ...) (exp-pred-exprs ...))))))
@@ -1027,13 +1019,13 @@
                     ;; no prop instantiations, no pred instantiations.
                     (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name qpd.prop-name)))
                     ;; no prop instantiations, pred instantiations.
-                    (syntax/loc stx (all  qpd.quant-decls (implies (qpd.pred-name qpd.pred-exprs) qpd.prop-name ))))
+                    (syntax/loc stx (all  qpd.quant-decls (implies (exp-pred-exprs ...) qpd.prop-name ))))
 
                     (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
                       ;; prop instantiations, no pred instantiations.
                       (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name  (qpd.prop-name qpd.prop-exprs))))
                       ;; prop instantiations, pred instantiations.
-                      (syntax/loc stx (all  qpd.quant-decls (implies  (qpd.pred-name qpd.pred-exprs  ) (qpd.prop-name qpd.prop-exprs )))))))
+                      (syntax/loc stx (all  qpd.quant-decls (implies  (exp-pred-exprs ...) (exp-prop-exprs ...)))))))
         ]
         
         

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -350,7 +350,7 @@
   (define-syntax-class QuantifiedPropertyDeclClass
     #:attributes (quant-decls prop-name prop-exprs pred-name pred-exprs constraint-type scope bounds)
     (pattern ((~datum QuantifiedPropertyDecl)
-              quant-decls:DeclListClass
+              -quant-decls:DeclListClass
               -prop-name:NameClass
               (~optional -prop-exprs:ExprListClass)
               (~and (~or "sufficient" "necessary") ct)
@@ -361,6 +361,7 @@
 
       ;;; I think this is wrong:
       ;;; I need to get quant-decls into the form ([n E]) where n are names in the namelist, and e is an Expr
+      #:with quant-decls #'-quant-decls.translate
       #:with prop-name #'-prop-name.name
       #:with pred-name #'-pred-name.name
       #:with pred-exprs (if (attribute -pred-exprs) #'pred-exprs.exprs #'()) 
@@ -985,7 +986,7 @@
 (define-syntax (QuantifiedPropertyDecl stx)
   (syntax-parse stx
     [qpd:QuantifiedPropertyDeclClass
-     #:do [(printf "qpd: ~a\n" (syntax->datum #'qpd))]
+     #:do [(printf "qpd-decls: ~a\n" (syntax->datum #'qpd.quant-decls))]
      #:with imp_total
             (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
 
@@ -994,8 +995,10 @@
               ;;; 1. We are not guaranteed that translate exists on qpd.quantdecls
               ;;; 2. It isn't enough to simply append pred-exprs to a predicate name to make an predicate call
 
-              (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.prop-name) qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
-              (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.pred-name) qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))
+              ;;; (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.prop-name) qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
+              ;;; (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.pred-name) qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))
+              (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name qpd.pred-name)))
+              (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name qpd.prop-name ))))
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
      (syntax/loc stx
        (test

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -350,7 +350,7 @@
   (define-syntax-class QuantifiedPropertyDeclClass
     #:attributes (quant-decls prop-name prop-exprs pred-name pred-exprs constraint-type scope bounds)
     (pattern ((~datum QuantifiedPropertyDecl)
-              -quant-decls:DeclListClass
+              quant-decls:DeclListClass
               -prop-name:NameClass
               (~optional -prop-exprs:ExprListClass)
               (~and (~or "sufficient" "necessary") ct)
@@ -359,12 +359,12 @@
               (~optional -scope:ScopeClass)
               (~optional -bounds:BoundsClass))
 
-      ;; This is certainly wrong. I need to get quant-decls into the form ([n E]) where n are names in the namelist, and e is an Expr
-      #:with quant-decls #'quant-decls.translate
+      ;;; I think this is wrong:
+      ;;; I need to get quant-decls into the form ([n E]) where n are names in the namelist, and e is an Expr
       #:with prop-name #'-prop-name.name
       #:with pred-name #'-pred-name.name
-      #:with pred-exprs (if (attribute -pred-exprs) #'pred-exprs.exprs #'()) ;;(datum->syntax #f (map my-expand (syntax->list #'pred-exprs.exprs))) #'())
-      #:with prop-exprs (if (attribute -prop-exprs) #'prop-exprs.exprs #'()) ;;(datum->syntax #f (map my-expand (syntax->list #'prop-exprs.exprs))) #'())
+      #:with pred-exprs (if (attribute -pred-exprs) #'pred-exprs.exprs #'()) 
+      #:with prop-exprs (if (attribute -prop-exprs) #'prop-exprs.exprs #'())
       #:with constraint-type (string->symbol (syntax-e #'ct))
       #:with scope (if (attribute -scope) #'-scope.translate #'())
       #:with bounds (if (attribute -bounds) #'-bounds.translate #'())))
@@ -997,9 +997,11 @@
      #:with imp_total
             (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
               ;; p => q : p is a sufficient condition for q
-              (syntax/loc stx (all qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs) (qpd.pred-name qpd.pred-exprs))))
+              ;;(syntax/loc stx (all qpd.quant-decls (implies (append qpd.prop-name qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
               ;; q => p : p is a necessary condition for q
-              (syntax/loc stx (all qpd.quant-decls (implies (qpd.pred-name qpd.pred-exprs) (qpd.prop-name qpd.prop-exprs)))))
+              ;;(syntax/loc stx (all qpd.quant-decls (implies (append qpd.pred-name qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))
+              (syntax/loc stx (all qpd.quant-decls.translate (implies qpd.prop-name qpd.pred-name)))
+              (syntax/loc stx (all qpd.quant-decls.translate (implies qpd.pred-name qpd.prop-name ))))
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
      (syntax/loc stx
        (test

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -344,9 +344,16 @@
     (pattern decl:TestExpectDeclClass)
     (pattern decl:PropertyDeclClass))
 
+
+  (define-syntax-class PropertyDeclQuantificationClass
+    #:attributes (quant quantdecls)
+    (pattern ((~datum PropertyDeclQuantificationClass)    
+              -quant:QuantClass
+              -quantdecls:QuantDecl)))
+
   (define-syntax-class PropertyDeclClass
     #:attributes (prop-name pred-name constraint-type scope bounds)
-    (pattern ((~datum PropertyDecl)      
+    (pattern ((~datum PropertyDecl)  
               -prop-name:NameClass
               (~and (~or "sufficient" "necessary") ct)
               -pred-name:NameClass
@@ -941,7 +948,8 @@
 (define-syntax (PropertyDecl stx)
   (syntax-parse stx
   [pwd:PropertyDeclClass 
-   #:with imp_total (if (eq? (syntax-e #'pwd.constraint-type) 'sufficient)
+   #:with imp_total 
+                    (if (eq? (syntax-e #'pwd.constraint-type) 'sufficient)
                         (syntax/loc stx (implies pwd.prop-name pwd.pred-name))  ;; p => q : p is a sufficient condition for q 
                         (syntax/loc stx (implies pwd.pred-name pwd.prop-name))) ;; q => p : p is a necessary condition for q
    #:with test_name (format-id stx "Assertion_~a_is_~a_for_~a" #'pwd.prop-name #'pwd.constraint-type #'pwd.pred-name)

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -348,19 +348,22 @@
 
   (define-syntax-class QuantifiedPropertyDeclClass
     #:attributes (quant-decls prop-name prop-exprs pred-name pred-exprs constraint-type scope bounds)
-    (pattern ((~datum PropertyDecl)
+    (pattern ((~datum QuantifiedPropertyDecl)
               (~optional "disj")
               -quant-decls: QuantDecl 
               -prop-name:NameClass
-              -prop-exprs:ExprListClass
+              (~optional -prop-exprs:ExprListClass)
               (~and (~or "sufficient" "necessary") ct)
               -pred-name:NameClass
-              -pred-exprs:ExprListClass
+              (~optional -pred-exprs:ExprListClass)
               (~optional -scope:ScopeClass)
               (~optional -bounds:BoundsClass))
+      #:with quant-decls #'-quant-decls.translate
       #:with prop-name #'-prop-name.name
       #:with pred-name #'-pred-name.name
-      #:with disj (if (attribute "disj") #t #f)
+      #:with pred-exprs (if (attribute -pred-exprs) (datum->syntax #f (map my-expand (syntax->list #'pred-exprs.exprs))) #'())
+      #:with prop-exprs (if (attribute -prop-exprs) (datum->syntax #f (map my-expand (syntax->list #'prop-exprs.exprs))) #'())
+      ;;; #:with disj (if (attribute "disj") #t #f) ;; TODO: Figure out disjoint
       #:with constraint-type (string->symbol (syntax-e #'ct))
       #:with scope (if (attribute -scope) #'-scope.translate #'())
       #:with bounds (if (attribute -bounds) #'-bounds.translate #'())))
@@ -982,8 +985,8 @@
     [qpd:QuantifiedPropertyDeclClass 
    
 ;; Tim, we can do something like:
-;(all ([x A]) (implies p q))
-; (all ([x A]) (implies (p x) (q x)))
+;; (all ([x A]) (implies p q))
+;;  (all ([x A]) (implies (p x) (q x)))
 
 
 ;;; (all ([x A]) (implies p q))
@@ -993,7 +996,7 @@
    #:with imp_total                    
                       (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
                         (syntax/loc stx  (all qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs) (qpd.pred-name qpd.pred-exprs))))  ;; p => q : p is a sufficient condition for q 
-                        (syntax/loc stx  (all qpd.quant-decls (implies (qpd.pred-name qpd.pred-exprs) (qpd.prop-name qpd.prop)))))  ;; q => p : p is a necessary condition for q
+                        (syntax/loc stx  (all qpd.quant-decls (implies (qpd.pred-name qpd.pred-exprs) (qpd.prop-name qpd.prop-exprs)))))  ;; q => p : p is a necessary condition for q
    #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
    (syntax/loc stx
       (test

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1023,20 +1023,7 @@
                       (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name  (qpd.prop-name qpd.prop-exprs))))
                       ;; prop instantiations, pred instantiations.
                       (syntax/loc stx (all  qpd.quant-decls (implies  (exp-pred-exprs ...) (exp-prop-exprs ...)))))))
-        ]
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        )
+        ])
      (syntax/loc stx
        (test
          test_name

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -985,23 +985,17 @@
 (define-syntax (QuantifiedPropertyDecl stx)
   (syntax-parse stx
     [qpd:QuantifiedPropertyDeclClass
-     ;; Debug print statement
-     ;;#:do [(printf "stx ~a\n" (syntax->datum stx))]
      #:do [(printf "qpd: ~a\n" (syntax->datum #'qpd))]
-      ;;; Tim, we can do something like:
-      ;;; (all ([x A]) (implies p q))
-      ;;; (all ([x A]) (implies (p x) (q x)))
-      ;;; https://github.com/tnelson/Forge/blob/main/forge/tests/forge-core/formulas/quantifiedFormulas.rkt
-
-
      #:with imp_total
             (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
-              ;; p => q : p is a sufficient condition for q
-              ;;(syntax/loc stx (all qpd.quant-decls (implies (append qpd.prop-name qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
-              ;; q => p : p is a necessary condition for q
-              ;;(syntax/loc stx (all qpd.quant-decls (implies (append qpd.pred-name qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))
-              (syntax/loc stx (all qpd.quant-decls.translate (implies qpd.prop-name qpd.pred-name)))
-              (syntax/loc stx (all qpd.quant-decls.translate (implies qpd.pred-name qpd.prop-name ))))
+
+              ;;; This is very broken. It isn't clear to me what to do.
+              ;;; Issues:
+              ;;; 1. We are not guaranteed that translate exists on qpd.quantdecls
+              ;;; 2. It isn't enough to simply append pred-exprs to a predicate name to make an predicate call
+
+              (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.prop-name) qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
+              (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.pred-name) qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
      (syntax/loc stx
        (test

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -995,7 +995,15 @@
     ;;;         Also, pred-exprs and prop-exprs are not being expanded correctly.
     ;;;         they are interpreted as joins when more than one name is in the list. 
     ;;;         Need to understand how to do this right.
-     #:with imp_total
+     
+    ;; TODO: Need a more unique test name
+     #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
+
+
+     (with-syntax 
+        (
+
+        [imp_total
           (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
                 ;; Sufficient case
                 (if (equal? (syntax->datum #'qpd.prop-exprs) '())
@@ -1010,7 +1018,7 @@
                       (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs ) qpd.pred-name)))
                       ;; prop instantiations, pred instantiations.
                       
-                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs) (qpd.pred-name qpd.pred-exprs))))))
+                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name (datum->syntax #f (map my-expand (syntax->list #'prop-exprs )))) (qpd.pred-name (datum->syntax #f (map my-expand (syntax->list #'pred-exprs )))))))))
                 ;; Necessary case
                 (if (equal? (syntax->datum #'qpd.prop-exprs) '())
                   (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
@@ -1024,13 +1032,20 @@
                       (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name  (qpd.prop-name qpd.prop-exprs))))
                       ;; prop instantiations, pred instantiations.
                       (syntax/loc stx (all  qpd.quant-decls (implies  (qpd.pred-name qpd.pred-exprs  ) (qpd.prop-name qpd.prop-exprs )))))))
-     
-    ;; TODO: Need a more unique test name
-     #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
-
-
-     (with-syntax 
-        ([(exprs ...) (datum->syntax #f (map my-expand (syntax->list #'pred-exprs )))])
+        ]
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        )
      (syntax/loc stx
        (test
          test_name

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -994,10 +994,12 @@
     [qpd:QuantifiedPropertyDeclClass  
     #:do (printf "qpd ~s~n" (syntax->datum #'qpd)) 
     #:do [(printf "qpd-pred-exprs: ~a\n" (syntax->datum #'qpd.pred-exprs))]
-      ;;; This is huge and could be simplified.
+    #:do [(printf "qpd-prop-exprs: ~a\n" (syntax->datum #'qpd.prop-exprs))]
+
 
     ;;; Issues: Disj not supported I think.
-
+    ;;;         Also, pred-exprs and prop-exprs are not being expanded correctly.
+    ;;;         they are interpreted as joins when more than one name is in the list. Need to understand how to do this right.
      #:with imp_total
           (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
                 ;; Sufficient case
@@ -1006,26 +1008,26 @@
                     ;; no prop instantiations, no pred instantiations.
                     (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name qpd.pred-name)))
                     ;; no prop instantiations, pred instantiations.
-                    (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name ( qpd.pred-name qpd.pred-exprs)))))
+                    (syntax/loc stx (all  qpd.quant-decls (implies qpd.prop-name (qpd.pred-name qpd.pred-exprs)))))
                     
                     (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
                       ;; prop instantiations, no pred instantiations.
-                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs) qpd.pred-name)))
+                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs ) qpd.pred-name)))
                       ;; prop instantiations, pred instantiations.
-                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs) ( qpd.pred-name qpd.pred-exprs))))))
+                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs ) (qpd.pred-name qpd.pred-exprs  ))))))
                 ;; Necessary case
                 (if (equal? (syntax->datum #'qpd.prop-exprs) '())
                   (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
                     ;; no prop instantiations, no pred instantiations.
                     (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name qpd.prop-name)))
                     ;; no prop instantiations, pred instantiations.
-                    (syntax/loc stx (all  qpd.quant-decls (implies ( qpd.pred-name qpd.pred-exprs) qpd.prop-name ))))
-                    
+                    (syntax/loc stx (all  qpd.quant-decls (implies (qpd.pred-name qpd.pred-exprs) qpd.prop-name ))))
+
                     (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 
                       ;; prop instantiations, no pred instantiations.
                       (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name  (qpd.prop-name qpd.prop-exprs))))
                       ;; prop instantiations, pred instantiations.
-                      (syntax/loc stx (all  qpd.quant-decls (implies  ( qpd.pred-name qpd.pred-exprs) (qpd.prop-name qpd.prop-exprs)))))))
+                      (syntax/loc stx (all  qpd.quant-decls (implies  (qpd.pred-name qpd.pred-exprs  ) (qpd.prop-name qpd.prop-exprs )))))))
      
 
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -985,9 +985,7 @@
     [qpd:QuantifiedPropertyDeclClass  
 
     ;;#:do [(printf "qpd-pred-name ~s~n" (syntax->datum #'qpd.pred-name)) ]
-    ;;; Issues: Disj not supported I think.
-
-     
+    ;;; Issues: Disj not working. Need to do a syntax match on the list, and find it from there.
     ;; TODO: Need a more unique test name
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
 
@@ -996,7 +994,6 @@
         (
           [(exp-pred-exprs ...) (datum->syntax stx (cons (syntax->datum #'qpd.pred-name) (syntax->datum #'qpd.pred-exprs)))]
           [(exp-prop-exprs ...) (datum->syntax stx (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs)))]
-          [_ (printf "exp-pred-exprs: ~a\n" (syntax->datum #'(exp-pred-exprs ...)))]
         [imp_total
           (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
                 ;; Sufficient case

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -984,9 +984,9 @@
   (syntax-parse stx
     [qpd:QuantifiedPropertyDeclClass  
     #:do (printf "qpd ~s~n" (syntax->datum #'qpd)) 
+    #:do [(printf "qpd-pred-name ~s~n" (syntax->datum #'qpd.pred-name)) ]
     #:do [(printf "qpd-pred-exprs: ~a\n" (syntax->datum #'qpd.pred-exprs))]
-    #:with ahah (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs))
-    #:do [(printf "cons : qpd-prop-exprs: ~a\n" (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs)))]
+    ;;#:do [(printf "cons : qpd-prop-exprs: ~a\n" (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs)))]
 
 
 
@@ -1000,9 +1000,11 @@
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
 
 
-     (with-syntax 
+     (with-syntax* 
         (
-
+          [(exp-pred-exprs ...) (datum->syntax stx (cons (syntax->datum #'qpd.pred-name) (syntax->datum #'qpd.pred-exprs)))]
+          [(exp-prop-exprs ...) (datum->syntax stx (cons (syntax->datum #'qpd.prop-name) (syntax->datum #'qpd.prop-exprs)))]
+          [_ (printf "exp-pred-exprs: ~a\n" (syntax->datum #'(exp-pred-exprs ...)))]
         [imp_total
           (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
                 ;; Sufficient case
@@ -1018,7 +1020,7 @@
                       (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name qpd.prop-exprs ) qpd.pred-name)))
                       ;; prop instantiations, pred instantiations.
                       
-                      (syntax/loc stx (all  qpd.quant-decls (implies (qpd.prop-name (datum->syntax #f (map my-expand (syntax->list #'prop-exprs )))) (qpd.pred-name (datum->syntax #f (map my-expand (syntax->list #'pred-exprs )))))))))
+                      (syntax/loc stx (all  qpd.quant-decls (implies (exp-prop-exprs ...) (exp-pred-exprs ...))))))
                 ;; Necessary case
                 (if (equal? (syntax->datum #'qpd.prop-exprs) '())
                   (if (equal? (syntax->datum #'qpd.pred-exprs) '()) 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -991,7 +991,9 @@
 
 (define-syntax (QuantifiedPropertyDecl stx)
   (syntax-parse stx
-    [qpd:QuantifiedPropertyDeclClass    
+    [qpd:QuantifiedPropertyDeclClass  
+    #:do (printf "qpd ~s~n" (syntax->datum #'qpd)) 
+    #:do [(printf "qpd-pred-exprs: ~a\n" (syntax->datum #'qpd.pred-exprs))]
       ;;; This is huge and could be simplified.
 
     ;;; Issues: Disj not supported I think.
@@ -1024,6 +1026,8 @@
                       (syntax/loc stx (all  qpd.quant-decls (implies qpd.pred-name  (qpd.prop-name qpd.prop-exprs))))
                       ;; prop instantiations, pred instantiations.
                       (syntax/loc stx (all  qpd.quant-decls (implies  ( qpd.pred-name qpd.pred-exprs) (qpd.prop-name qpd.prop-exprs)))))))
+     
+
      #:with test_name (format-id stx "Quantified_Assertion_~a_is_~a_for_~a" #'qpd.prop-name #'qpd.constraint-type #'qpd.pred-name)
      (syntax/loc stx
        (test

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -998,9 +998,11 @@
      #:with imp_total
             (if (eq? (syntax-e #'qpd.constraint-type) 'sufficient)
 
-              ;;; This is very broken. It isn't clear to me what to do.
+              ;;; This is broken. It isn't clear to me what to do.
               ;;; Issues:
-              ;;; 1. It isn't enough to simply append pred-exprs to a predicate name to make an predicate call. 
+              ;;; 1. (qpd.prop-name qpd.prop-exprs) is not enough for a call. In the case that  
+              ;;;  prop does not take any arguments, we cannot *just* call the list. May need some deep nesting.
+              ;;; 2. Do not currently support disj
 
               ;;; (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.prop-name) qpd.prop-exprs) (append qpd.pred-name qpd.pred-exprs))))
               ;;; (syntax/loc stx (all qpd.quant-decls.translate (implies (append (list qpd.pred-name) qpd.pred-exprs) (append qpd.prop-name qpd.prop-exprs)))))

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -43,5 +43,5 @@ test expect {
 
 // This does not pass
 
-assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
-//assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  
+//assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
+assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -25,7 +25,7 @@ pred arethesame [x : Node, y : Node] {
     x = y
 }
 
-
+/*
 // Quantifiers not needed
 assert all x : Node | isDirectedTree is necessary for isDirectedTree
 assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
@@ -33,6 +33,13 @@ assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
 
 // Allow multiple quantifications
 assert all r : NonNode, r1 : Node | isRoot[r1] is necessary for isDirectedTree for 1 Node
+
+test expect {
+
+    t1 : {all r1, r2 : Node | arethesame[r1, r2] implies arethesame[r1, r2]  } is theorem
+}
+*/
+
 
 // This does not pass
 assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -13,7 +13,7 @@ pred isDirectedTree {
 pred isRoot[r : Node] {
 	isDirectedTree
     one r
-    r in edges.Node - Node.edges
+    (some edges) => (r in edges.Node - Node.edges)
 }
 
 pred bothRoots[x : Node, y : Node] {
@@ -21,11 +21,10 @@ pred bothRoots[x : Node, y : Node] {
     isRoot[y]
 }
 
-pred eq [x : Node, y : Node] {
+pred arethesame [x : Node, y : Node] {
     x = y
 }
 
-assert all r1, r2 : Node | bothRoots[r1, r2] is sufficient for eq[r1, r2]
 
 // Quantifiers not needed
 assert all x : Node | isDirectedTree is necessary for isDirectedTree
@@ -33,5 +32,7 @@ assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
 
 
 // Allow multiple quantifications
-assert all r : NonNode, r1, r2 : Node | isRoot[r1] is necessary for isDirectedTree
+assert all r : NonNode, r1 : Node | isRoot[r1] is necessary for isDirectedTree for 1 Node
 
+// This does not pass
+assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -38,4 +38,4 @@ assert all r : NonNode, r1 : Node | isRoot[r1] is necessary for isDirectedTree f
 assert all x : Node | isDirectedTree is necessary for isDirectedTree
 assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
 assert all r1, r2 : Node | arethesame[r1, r2] is necessary for arethesame[r1, r2]  
-assert all r1, r2 : Node | bothRoots[r1, r2] is sufficient for arethesame[r1, r2]  for 1 Node
+assert all r1, r2 : Node | bothRoots[r1, r2] is sufficient for arethesame[r1, r2] 

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -27,7 +27,7 @@ pred arethesame [x : Node, y : Node] {
 
 /*
 // Quantifiers not needed
-assert all x : Node | isDirectedTree is necessary for isDirectedTree
+
 assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
 
 
@@ -42,6 +42,6 @@ test expect {
 
 
 // This does not pass
-
+//assert all x : Node | isDirectedTree is necessary for isDirectedTree
 //assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
 assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -1,0 +1,37 @@
+#lang forge
+
+sig NonNode {}
+sig Node {edges: set Node}
+
+pred isDirectedTree {
+	edges.~edges in iden -- Injective, each child has at most one parent
+	lone edges.Node - Node.edges -- At most one element that does not have a parent
+	no (^edges & iden) -- No loops
+	lone Node or Node in edges.Node + Node.edges -- Either one node or every node has either a child or a parent.
+}
+
+pred isRoot[r : Node] {
+	isDirectedTree
+    one r
+    r in edges.Node - Node.edges
+}
+
+pred bothRoots[x : Node, y : Node] {
+    isRoot[x]
+    isRoot[y]
+}
+
+pred eq [x : Node, y : Node] {
+    x = y
+}
+
+assert all r1, r2 : Node | bothRoots[r1, r2] is sufficient for eq[r1, r2]
+
+// Quantifiers not needed
+assert all x : Node | isDirectedTree is necessary for isDirectedTree
+assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
+
+
+// Allow multiple quantifications
+assert all r : NonNode, r1, r2 : Node | isRoot[r1] is necessary for isDirectedTree
+

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -25,7 +25,6 @@ pred arethesame [x : Node, y : Node] {
     x = y
 }
 
-/*
 // Quantifiers not needed
 
 assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
@@ -34,14 +33,9 @@ assert all r1, r2 : Node | isDirectedTree is sufficient for isDirectedTree
 // Allow multiple quantifications
 assert all r : NonNode, r1 : Node | isRoot[r1] is necessary for isDirectedTree for 1 Node
 
-test expect {
-
-    t1 : {all r1, r2 : Node | arethesame[r1, r2] implies arethesame[r1, r2]  } is theorem
-}
-*/
-
 
 // This does not pass
-//assert all x : Node | isDirectedTree is necessary for isDirectedTree
-//assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
-assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  
+assert all x : Node | isDirectedTree is necessary for isDirectedTree
+assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
+assert all r1, r2 : Node | arethesame[r1, r2] is necessary for arethesame[r1, r2]  
+assert all r1, r2 : Node | bothRoots[r1, r2] is sufficient for arethesame[r1, r2]  for 1 Node

--- a/forge/tests/forge/other/quantified-assertions.frg
+++ b/forge/tests/forge/other/quantified-assertions.frg
@@ -42,4 +42,6 @@ test expect {
 
 
 // This does not pass
-assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  
+
+assert all r1, r2 : Node | isRoot[r1] is sufficient for isRoot[r1]
+//assert all r1, r2 : Node | arethesame[r1, r2] is sufficient for arethesame[r1, r2]  


### PR DESCRIPTION
Universal assertions of the form:

`assert all r1 : Node | isRoot[r1] is necessary for isDirectedTree`
`assert all r1, r2 : Node | isRoot[r1] is necessary for q[r2]`
`assert all a,b : N1, c,d : N2 | p[a,b] is sufficient for s[c,d]`

are now supported. 

### Issues:
- We only support universal quantification 
- Currently ignore the `disj` keyword

### TODO

- Negative tests