### PR TITLE
Shoring up core language's ability to give a target instance to solver for minimization etc. 

### DIFF
--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -313,7 +313,8 @@
           (get-atoms relation atoms)))))
 
     ; Always say what mode; admittedly this won't always make sense if untargeted
-    ; Conflate "target distance" declared with a concrete target and global mode
+    ; Conflate "target distance" declared with a concrete target and global mode.
+    ;    Note well: the space of possible options should mirror the contract on this field.
     (pardinus-print
      (pardinus:print-cmd "(target-option target-mode ~a)"
                          (if target

--- a/forge/sigs-functional.rkt
+++ b/forge/sigs-functional.rkt
@@ -662,7 +662,12 @@
                   #:name name
                   #:preds preds
                   #:scope scope-input
-                  #:bounds bounds-input))
+                  #:bounds bounds-input
+                  ;#:solver solver
+                  ;#:backend backend
+                  #:target target
+                  ;#:command command
+                  ))
 
 (define/contract (check-from-state state
                                    #:name [name 'unnamed-check]

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -138,7 +138,9 @@
 ; A Target describes the goal of a target-oriented model-finding run.
 (struct/contract Target (
   [instance (hash/c symbol? (listof (listof symbol?)))]
-  [distance (or/c 'close 'far)]
+  ; This is not the same as option target_mode, which provides a global default.
+  ; Rather, this is per target.
+  [distance (or/c 'close_noretarget 'far_noretarget 'close_retarget 'far_retarget 'hamming_cover)]
   ) #:transparent)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -264,7 +266,8 @@
         'min_tracelength exact-positive-integer?
         'max_tracelength exact-positive-integer?
         'problem_type symbol?
-        'target_mode symbol?
+        'target_mode (lambda (x)
+                       (member x '(close_noretarget far_noretarget close_retarget far_retarget hamming_cover)))
         'core_minimization symbol?
         'skolem_depth exact-integer?
         'local_necessity symbol?

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -554,7 +554,7 @@
          (define run-solver (~? 'solver-choice #f))
          (define run-backend (~? 'backend #f))
          (define run-target
-           (~? (Target (cdr target-instance)
+           (~? (Target target-instance ;(cdr target-instance)
                        (~? 'target-distance 'close))
                #f))
          (define run-command #'#,command)         

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -555,7 +555,7 @@
          (define run-backend (~? 'backend #f))
          (define run-target
            (~? (Target target-instance ;(cdr target-instance)
-                       (~? 'target-distance 'close))
+                       (~? 'target-distance 'close_noretarget))
                #f))
          (define run-command #'#,command)         
          (define name

--- a/forge/tests/forge-core/other/target-oriented.rkt
+++ b/forge/tests/forge-core/other/target-oriented.rkt
@@ -1,0 +1,58 @@
+#lang forge/core
+(set-option! 'verbose 0)
+
+; Tests for target-oriented interface. The tests in ../forge/target/ test the _forge language_
+; for target _types_, but not for providing a specific target. Hence this module. 
+
+(require (prefix-in @ rackunit))
+
+(sig Node)
+(relation edges (Node Node))
+
+(set-option! 'verbose 5)
+(set-option! 'solver 'PMaxSAT4J)
+(set-option! 'problem_type 'target)
+
+; TODO: error if solver not appropriate for target-orientation
+; TODO: error if solver name not valid
+
+; TODO: parser issue
+
+; Create a Run, but don't open a visualizer
+; We cannot use "test" here; we need to view the contents of the instance itself. 
+;; (run target-close-empty
+;;      #:preds []
+;;      #:target (hash 'Node '() 'edges '())
+;;      #:target-distance close)
+;; (define target-close-empty-gen (forge:make-model-generator (forge:get-result target-close-empty) 'next))
+;; (define target-close-empty-inst1 (target-close-empty-gen))
+
+(run target-close-biggest-2
+     #:preds []
+     #:target (hash 'Node '((Node0) (Node1))
+                    'edges '( (Node0 Node1) (Node1 Node0) (Node0 Node0) (Node1 Node1)))
+     #:target-distance close)
+(define target-close-biggest-2-gen (forge:make-model-generator (forge:get-result target-close-biggest-2) 'next))
+(define target-close-biggest-2-inst1 (target-close-biggest-2-gen))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  
+;; (@check-equal?
+;;  (length (forge:bound-upper (first (filter (lambda (x) (equal? A (forge:bound-relation x))) (forge:Run-kodkod-bounds myRun)))))
+;;  1
+;;  "#:one sigs should have exactly one element in their upper bound")
+;;  
+;; (@check-equal?
+;;  (forge:bound-upper (first (filter (lambda (x) (equal? A (forge:bound-relation x))) (forge:Run-kodkod-bounds myRun))))
+;;  (forge:bound-lower (first (filter (lambda (x) (equal? A (forge:bound-relation x))) (forge:Run-kodkod-bounds myRun))))
+;;  "#:one sigs should be exact-bounded")
+;; 
+;;  
+;; (@check-not-equal?
+;;  (forge:bound-upper (first (filter (lambda (x) (equal? A (forge:bound-relation x))) (forge:Run-kodkod-bounds myRun))))
+;;  (forge:bound-upper (first (filter (lambda (x) (equal? B (forge:bound-relation x))) (forge:Run-kodkod-bounds myRun))))
+;;  "Upper bounds between #:one siblings should never overlap")
+;; 
+;; ; Safety check: Regardless of what we think bounds do, confirm that overlap is impossible
+;; (test oneSigsCannotOverlap #:preds [(some (& A B))] #:expect unsat)


### PR DESCRIPTION
Correcting some minor bit-rot in the pipeline to pass target instances to Pardinus. This isn't exposed in the surface Forge languages yet, but allows us to experimentally generate (e.g.) minimal instances, etc. via the Racket library.