### PR TITLE
Sig and Field AST nodes will now properly record the source location of their use

### DIFF
--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -343,6 +343,7 @@
            ; a macro constructor that captures the syntax location of the call site
            ;  (good for, e.g., test cases + parser)
            (define-syntax (id stx2)
+             (printf "macro: ~a~n" stx2)
              (syntax-case stx2 ()
                 [(_ (#:lang check-lang) e ellip)                
                   (quasisyntax/loc stx2

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -343,7 +343,6 @@
            ; a macro constructor that captures the syntax location of the call site
            ;  (good for, e.g., test cases + parser)
            (define-syntax (id stx2)
-             (printf "macro: ~a~n" stx2)
              (syntax-case stx2 ()
                 [(_ (#:lang check-lang) e ellip)                
                   (quasisyntax/loc stx2

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1365,7 +1365,15 @@
                     (node/expr-arity astnode) (node/expr/relation-name astnode) (node/expr/relation-typelist-thunk astnode)
                     (node/expr/relation-parent astnode) (node/expr/relation-is-variable astnode) (node/expr/relation-name astnode)
                     (forge:Sig-one astnode) (forge:Sig-lone astnode) (forge:Sig-abstract astnode) (forge:Sig-extends astnode))]
+        [(forge:Relation? astnode)
+         (define new-info (nodeinfo loc (nodeinfo-lang (node-info astnode))))
+         (forge:Relation new-info
+                         (node/expr-arity astnode) (node/expr/relation-name astnode) (node/expr/relation-typelist-thunk astnode)
+                         (node/expr/relation-parent astnode) (node/expr/relation-is-variable astnode) (node/expr/relation-name astnode)
+                         ;(forge:Relation-name astnode)
+                         (forge:Relation-sigs-thunks astnode) (forge:Relation-breaker astnode))]
         [else astnode]))
+
 
 ; --------------------------
 ; these used to be define-simple-macro, but define-simple-macro doesn't

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -44,6 +44,7 @@
 ; Forge-specific information, which often leads to added
 ; constraints.
 
+; DO NOT EXTEND THIS SIG
 (struct Sig node/expr/relation (
   name ; symbol?
   one ; boolean?
@@ -55,6 +56,7 @@
   [(define (write-proc self port mode)
      (fprintf port "(Sig ~a)" (Sig-name self)))])
 
+; DO NOT EXTEND THIS SIG
 (struct Relation node/expr/relation (
   name ; symbol?
   sigs-thunks ; (listof (-> Sig?))

--- a/forge/tests/error/loc/field_use_loc_error.frg
+++ b/forge/tests/error/loc/field_use_loc_error.frg
@@ -1,0 +1,8 @@
+#lang forge/bsl
+
+sig Person {age: one Int}
+one sig Nim extends Person {}
+
+test expect {
+    should_error: {reachable[age, Nim, Nim]} is sat
+}

--- a/forge/tests/error/loc/sig_use_loc_error.frg
+++ b/forge/tests/error/loc/sig_use_loc_error.frg
@@ -1,0 +1,8 @@
+#lang forge/bsl
+
+sig Person {age: one Int}
+one sig Nim extends Person {}
+
+test expect {
+    should_error: {reachable[Nim, Nim, Nim]} is sat
+}

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -21,6 +21,10 @@
 
 (define REGISTRY
   (list
+    ;;;;;;; Source locations ;;;;;;;
+    (list "./loc/sig_use_loc_error.frg" #rx"sig_use_loc_error.frg:7:39") ; vs. reachable
+    (list "./loc/field_use_loc_error.frg" #rx"field_use_loc_error.frg:7:29")   ; vs. reachable
+   
     (list "piecewise-bind-repeat.frg" #rx"rebinding detected")
     (list "piecewise-bind-combine.frg" #rx"may not be combined with complete bounds")
     (list "piecewise-bind-sigs.frg" #rx"would create a relation")


### PR DESCRIPTION
References to sigs and fields expand to Racket identifiers, and those identifiers are bound by the declaration site. This means that every reference to a sig or field in a Forge formula would, previously, have only their _declaration_ site for source location. 

This PR enriches expanded sig/field references with source location information for the _use_ site. 