### PR TITLE
Add fixes for predicate and function source locations

### DIFF
--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -44,6 +44,7 @@
 ;     * node/formula/sealed
 ;       * wheat
 ;   * node/int -- integer expression
+;     * node/int/sum-quant -- sum "quantified" form
 ;     * node/int/op (children)
 ;       * node/int/op/add
 ;       * ...

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -48,7 +48,6 @@
 ;       * node/int/op/add
 ;       * ...
 ;     * node/int/constant (value) -- int constant
-;   * node/unknown -- delayed binding of identifiers for predicates and functions
 ;; -----------------------------------------------------------------------------
 
 ; Struct to hold metadata about an AST node (like source location)

--- a/forge/lang/deparse.rkt
+++ b/forge/lang/deparse.rkt
@@ -60,6 +60,8 @@
             (deparse-expr arg 20)]
         [(? node/int?)
             (deparse-int arg 20)]
+        [(? procedure?)
+            (format "(Racket procedure, which is likely an unexpected predicate or function definition: ~a)" arg)]
         [else 
             (format "(COULD-NOT-DEPARSE: ~a)" arg)]))
 

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1299,12 +1299,9 @@
 
     
   [((~datum Expr) expr1:ExprClass "[" exprs:ExprListClass "]")
-   (define result
      (with-syntax ([expr1 (my-expand #'expr1)]
                    [(exprs ...) (datum->syntax #f (map my-expand (syntax->list #'(exprs.exprs ...))))])
-       (syntax/loc stx (expr1 exprs ...))))
-   ;(printf "result: ~a~n" result)
-   result]
+       (syntax/loc stx (expr1 exprs ...)))]
 
   [((~datum Expr) "~" expr1:ExprClass)
    (with-syntax ([expr1 (my-expand #'expr1)])

--- a/forge/last-checker.rkt
+++ b/forge/last-checker.rkt
@@ -53,17 +53,17 @@
     [(node/formula/constant info type)
      (check-and-output formula node/formula/constant checker-hash #f)]
 
-    [(node/fmla/pred-spacer info name args expanded)
-     (checkFormula run-or-state expanded quantvars checker-hash)]
+    ;[(node/fmla/pred-spacer info name args expanded)
+    ; (checkFormula run-or-state expanded quantvars checker-hash)]
 
-    ; [(node/fmla/pred-spacer info name args expanded)
-    ;   (define quantvar/list (map (lambda (x) (car (cdr x))) quantvars))
-    ;   (define arg/list (map (lambda (x) (mexpr-expr (apply-record-domain x))) args))
-    ;   (if (not (equal? quantvar/list arg/list)) ; doesn't work when not all arguments are quantified variables
-    ;       (raise-forge-error
-    ;       #:msg (format "The sig(s) given as an argument to predicate ~a are of incorrect type" name)
-    ;       #:context info) ; points to predicate, not where predicate application happened
-    ;       (checkFormula run-or-state expanded quantvars checker-hash))]
+     [(node/fmla/pred-spacer info name args expanded)
+       (define quantvar/list (map (lambda (x) (car (cdr x))) quantvars))
+       (define arg/list (map (lambda (x) (mexpr-expr (apply-record-domain x))) args))
+       (if (not (equal? quantvar/list arg/list)) ; doesn't work when not all arguments are quantified variables
+           (raise-forge-error
+           #:msg (format "The sig(s) given as an argument to predicate ~a are of incorrect type" name)
+           #:context info) ; points to predicate, not where predicate application happened
+           (checkFormula run-or-state expanded quantvars checker-hash))]
     
     [(node/formula/op info args)
      (check-and-output formula

--- a/forge/sigs-structs.rkt
+++ b/forge/sigs-structs.rkt
@@ -403,12 +403,14 @@ Returns whether the given run resulted in sat or unsat, respectively.
 
 ; get-pred :: Run-or-State, Symbol -> Predicate
 ; Gets a predicate by name from a given state
+; Note that this will return the procedure, not the macro (no stx loc capture)
 (define (get-pred run-or-state name)
   (define state (get-state run-or-state))
   (hash-ref (State-pred-map state) name))
 
 ; get-fun :: Run-or-State, Symbol -> Function
 ; Gets a function by name from a given state
+; Note that this will return the procedure, not the macro (no stx loc capture)
 (define (get-fun run-or-state name)
   (define state (get-state run-or-state))
   (hash-ref (State-fun-map state) name))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -456,12 +456,19 @@
            (quasisyntax/loc stx
              (begin
                ; - Use a macro in order to capture the location of the _use_.
+               ;(define-syntax (name stx2)
+               ;  (syntax-parse stx2
+               ;    [name
+               ;     (quasisyntax/loc stx2
+               ;       (lambda (decls.name ...)
+               ;         (functionname decls.name ... #:info (nodeinfo (inner-unsyntax (build-source-location stx2)) check-lang))))]))
+
                (define-syntax (name stx2)
                  (syntax-parse stx2
-                   [name
+                   [(name args (... ...))
                     (quasisyntax/loc stx2
-                      (lambda (decls.name ...)
-                        (functionname decls.name ... #:info (nodeinfo (inner-unsyntax (build-source-location stx2)) check-lang))))]))
+                      (functionname args (... ...) #:info (nodeinfo
+                                                           (inner-unsyntax (build-source-location stx2)) check-lang)))]))
                ; - "pred spacer" added to record use of predicate along with original argument declarations etc.
                (define (functionname decls.name ... #:info [the-info #f])
                  (unless (or (integer? decls.name) (node/expr? decls.name) (node/int? decls.name))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -442,18 +442,33 @@
     [(pred pt:pred-type
            (~optional (#:lang check-lang) #:defaults ([check-lang #''checklangNoCheck]))
            (name:id decls:param-decl-class  ...+) conds:expr ...+)
-     (with-syntax ([the-info #`(nodeinfo #,(build-source-location stx) check-lang)])
-       (quasisyntax/loc stx
-         (begin
-           ; "pred spacer" added to record use of predicate along with original argument declarations etc.           
-           (define (name decls.name ...)
-             (unless (or (integer? decls.name) (node/expr? decls.name) (node/int? decls.name))
-               (error (format "Argument '~a' to pred ~a was not a Forge expression, integer-expression, or Racket integer. Got ~v instead."
-                              'decls.name 'name decls.name)))
-             ...
-             (pt.seal (node/fmla/pred-spacer the-info 'name (list (apply-record 'decls.name decls.mexpr decls.name) ...)
-                                             (&&/info the-info conds ...))))                      
-           (update-state! (state-add-pred curr-state 'name name)))))]))
+     (with-syntax ([decl-info #`(nodeinfo #,(build-source-location stx) check-lang)]
+                   [inner-unsyntax #'unsyntax])
+       (define result-stx
+         (with-syntax ([functionname (format-id #'name "~a/func" #'name)])
+           (quasisyntax/loc stx
+             (begin
+               ; "pred spacer" added to record use of predicate along with original argument declarations etc.
+               ; Use a macro in order to capture the location of the _use_.
+               ;; TODO: issue that the above (no-args expansion) isn't doing the below
+               ;; TODO: issue that the *state* will store only the predicate will be the function, not the macro, so won't extract stxloc
+               
+               (define-syntax (name stx2)
+                 (syntax-parse stx2
+                   [name
+                    (quasisyntax/loc stx2
+                      (lambda (decls.name ...)
+                        (functionname decls.name ... #:info (nodeinfo (inner-unsyntax (build-source-location stx2)) check-lang))))]))
+               
+               (define (functionname decls.name ... #:info [the-info #f])
+                 (unless (or (integer? decls.name) (node/expr? decls.name) (node/int? decls.name))
+                   (error (format "Argument '~a' to pred ~a was not a Forge expression, integer-expression, or Racket integer. Got ~v instead."
+                                  'decls.name 'name decls.name)))
+                 ...
+                 (pt.seal (node/fmla/pred-spacer the-info 'name (list (apply-record 'decls.name decls.mexpr decls.name) ...)
+                                                 (&&/info the-info conds ...)))) 
+               (update-state! (state-add-pred curr-state 'name functionname)))))) 
+       result-stx)]))
 
 (define/contract (repeat-product expr count)
   [@-> node/expr? number? node/expr?]

--- a/forge/tests/error/expect-fun-args.frg
+++ b/forge/tests/error/expect-fun-args.frg
@@ -1,0 +1,12 @@
+#lang forge/bsl
+option verbose 0 
+option run_sterling off
+abstract sig Player {}
+one sig X, O extends Player {}
+sig Board {board: pfunc Int -> Int -> Player}
+
+fun playerAt[b: Board, row, col: Int]: lone Player {
+  b.board[row][col] }
+
+test expect { should_error: { some playerAt } is sat }
+

--- a/forge/tests/error/expect-fun-no-args.frg
+++ b/forge/tests/error/expect-fun-no-args.frg
@@ -1,0 +1,11 @@
+#lang forge/bsl
+option verbose 0 
+option run_sterling off
+abstract sig Player {}
+one sig X, O extends Player {}
+sig Board {board: pfunc Int -> Int -> Player}
+
+fun xplayer: lone Player { X }
+
+test expect { should_error: { xplayer[O] = X } is sat }
+

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -28,6 +28,11 @@
     (list "expect-predicate-args.frg" #rx"Ill-formed block")
     (list "expect-predicate-no-args.frg" #rx"expect-predicate-no-args.frg:13:45.*Tried to give arguments to a predicate, but it takes none")
 
+    ; TODO: needs switch to raise-forge-error so the proper location is in the message
+    ; (list "expect-fun-args.frg" #rx"Racket procedure, which is likely.*expect-fun-args.frg:11")
+    ; TODO: needs to confirm that equality is irrespective of source location (it should be)
+    ;(list "expect-fun-no-args.frg" #rx"TODO")
+
     ;;;;;;;;;;;;;;;;;;;;;;;;
     
     (list "piecewise-bind-repeat.frg" #rx"rebinding detected")

--- a/forge/tests/error/main.rkt
+++ b/forge/tests/error/main.rkt
@@ -21,6 +21,15 @@
 
 (define REGISTRY
   (list
+    ;;;;;;;;;;;;;;;;;;;;;;;;
+    ; Some error tests look at the specific source-location blamed
+   
+    ; misuse of predicates and helper functions with arguments/no-arguments
+    (list "expect-predicate-args.frg" #rx"Ill-formed block")
+    (list "expect-predicate-no-args.frg" #rx"expect-predicate-no-args.frg:13:45.*Tried to give arguments to a predicate, but it takes none")
+
+    ;;;;;;;;;;;;;;;;;;;;;;;;
+    
     (list "piecewise-bind-repeat.frg" #rx"rebinding detected")
     (list "piecewise-bind-combine.frg" #rx"may not be combined with complete bounds")
     (list "piecewise-bind-sigs.frg" #rx"would create a relation")
@@ -115,8 +124,6 @@
     (list "expr-in-comprehension-condition.frg" #rx"expected a formula")
     (list "non-expr-in-comprehension-domain.frg" #rx"expected a singleton or relational expression")
     (list "arity-in-comprehension-domain.frg" #rx"variable domain needs arity = 1")
-    (list "expect-predicate-args.frg" #rx"Ill-formed block")
-    (list "expect-predicate-no-args.frg" #rx"Tried to give arguments to a predicate, but it takes none")
 
     (list "override-wrong-arity.frg" #rx"must have same arity")
     (list "override-no-overlap.frg" #rx"will never override anything")

--- a/forge/tests/forge-functional/other/ast-nodes.rkt
+++ b/forge/tests/forge-functional/other/ast-nodes.rkt
@@ -62,15 +62,21 @@
 (sig A)
 (sig B)
 (@check-not-equal? A B)
+(@check-true (node/expr? A))
 
 (pred (isA x) (= A x))
 (define isA_B (isA B))
-(@check-true node/formula? isA_B)
-(@check-true node/formula/op? isA_B)
-(printf "~a~n" isA_B)
-;(define isA_B_inner_eq (node/formula/op-children isA_B))
-;(printf isA_B_inner_eq)
-;(@check-equal? A (isA_B)
+(@check-true (node/formula? isA_B))
+(@check-true (node/fmla/pred-spacer? isA_B))
+
+;; remove the spacer and enclosing &&, etc.
+(define isA_B_inner_eq (first (node/formula/op-children (node/fmla/pred-spacer-expanded isA_B))))
+(define use_A (first (node/formula/op-children isA_B_inner_eq)))
+; definition node and use node are considered equal
+(@check-equal? A use_A)
+; but they carry different location information
+(@check-not-equal? (srcloc-line (nodeinfo-loc (node-info A))) 
+                   (srcloc-line (nodeinfo-loc (node-info use_A))))
 
 
 

--- a/forge/tests/forge-functional/other/ast-nodes.rkt
+++ b/forge/tests/forge-functional/other/ast-nodes.rkt
@@ -5,12 +5,21 @@
 (require (prefix-in @ rackunit))
 
 ; Tests for AST node equality, etc.
+; Equality should apply irrespective of source location information.
+
+; Note there is some test-duplication between here and the forge-core version.
+;  DO NOT DELETE ONE IN FAVOR OF THE OTHER (especially without confirming that they are 
+;  in fact identical!)
 
 (@check-equal? univ univ)
 (@check-equal? true true)
 (@check-equal? (join iden iden) (join iden iden))
 (@check-equal? (in (join iden iden) (join iden iden))
                (in (join iden iden) (join iden iden)))
+
+; Quantifier variables (node/expr/quantifier-var) have a "sym" field that should be
+; distinct, even if the variable name is the same. This helps to detect shadowing, etc.
+; But as a result, it is not safe to consider "x" = "x" here.
 (@check-not-equal? (some ([x univ]) (in x x))
                    (some ([x univ]) (in x x)))
 (@check-equal? (some univ)
@@ -46,6 +55,23 @@
 ; Unsafe: small chance will fail since non-equal values may hash the same
 (@check-not-equal? (equal-hash-code univ)
                    (equal-hash-code iden))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Test equality for Sig and Relation nodes across aliasing
+(sig A)
+(sig B)
+(@check-not-equal? A B)
+
+(pred (isA x) (= A x))
+(define isA_B (isA B))
+(@check-true node/formula? isA_B)
+(@check-true node/formula/op? isA_B)
+(printf "~a~n" isA_B)
+;(define isA_B_inner_eq (node/formula/op-children isA_B))
+;(printf isA_B_inner_eq)
+;(@check-equal? A (isA_B)
+
 
 
 

--- a/forge/tests/forge-functional/other/ast-nodes.rkt
+++ b/forge/tests/forge-functional/other/ast-nodes.rkt
@@ -57,27 +57,7 @@
                    (equal-hash-code iden))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; Test equality for Sig and Relation nodes across aliasing
-(sig A)
-(sig B)
-(@check-not-equal? A B)
-(@check-true (node/expr? A))
-
-(pred (isA x) (= A x))
-(define isA_B (isA B))
-(@check-true (node/formula? isA_B))
-(@check-true (node/fmla/pred-spacer? isA_B))
-
-;; remove the spacer and enclosing &&, etc.
-(define isA_B_inner_eq (first (node/formula/op-children (node/fmla/pred-spacer-expanded isA_B))))
-(define use_A (first (node/formula/op-children isA_B_inner_eq)))
-; definition node and use node are considered equal
-(@check-equal? A use_A)
-; but they carry different location information
-(@check-not-equal? (srcloc-line (nodeinfo-loc (node-info A))) 
-                   (srcloc-line (nodeinfo-loc (node-info use_A))))
-
-
-
-
+; Not testing equality for sig/relation nodes across aliasing here,
+; since that's only done in the Forge expander at the moment.
+; In forge/core, syntax location must be modified manually.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/forge/tests/forge/expressions/expressionOperators.rkt
+++ b/forge/tests/forge/expressions/expressionOperators.rkt
@@ -118,7 +118,7 @@ test expect ExpressionOperators {
     autoConvertIntFun : {canConvertIntExprNullary <= #Node} is theorem
     autoConvertIntFun_args : {canConvertIntExprUnary[Node] <= #Node} is theorem
 
-    -- Regression test for last-checker/join/spacer issue; Jan 05 2023
+    -- Regression test for last-checker/join/spacer issue; Jan 05 2024
     regression_join_on_spacer : {
         some n: Node | { 
             some forceSpacerAroundNode[n].edges

--- a/forge/tests/srclocs/main.rkt
+++ b/forge/tests/srclocs/main.rkt
@@ -4,37 +4,68 @@
 
 (require (rename-in rackunit [check rackunit-check])
          (only-in rackunit check-true check-equal? check-not-eq?))
-(require (only-in racket flatten first second string-contains?))
+(require (only-in racket flatten first second string-contains?)
+         (prefix-in @ (only-in racket -)))
 
 ; Returns a list of all AST nodes in this tree
-(define (gather-tree n #:leafs-only leafs-only)
+(define (gather-tree n #:leafs-only leafs-only #:ignore-outer ignore-outer)
+  (define ignore (if (< 1 ignore-outer) 0 (@- ignore-outer 1)))
+
+  ;; Helper for AST nodes that have a quantified structure
+  (define (gather-quant-helper e)
+    (define decls (cond [(node/formula/quantified? e)
+                         (node/formula/quantified-decls e)]
+                        [(node/expr/comprehension? e)
+                         (node/expr/comprehension-decls e)]
+                        [else
+                         (node/int/sum-quant-decls e)]))
+    (define fmla (cond [(node/formula/quantified? e)
+                        (node/formula/quantified-formula e)]
+                       [(node/expr/comprehension? e)
+                        (node/expr/comprehension-formula e)]
+                       [else
+                        (node/int/sum-quant-int-expr e)]))
+    (append
+     ; Gather both decl variables and decl expressions (and their subexpressions)
+     (flatten (map (lambda (decl)
+                     (list (gather-tree (car decl) #:leafs-only leafs-only #:ignore-outer ignore)
+                           (gather-tree (cdr decl) #:leafs-only leafs-only #:ignore-outer ignore)))
+                   decls))
+     (gather-tree fmla #:leafs-only leafs-only #:ignore-outer ignore)))
+  
   (define descendents
     (cond [(node/expr/op? n)
-           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only #:ignore-outer ignore))
                          (node/expr/op-children n)))]
           [(node/formula/op? n)
-           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only #:ignore-outer ignore))
                          (node/formula/op-children n)))]
           [(node/int/op? n)
-           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only))
+           (flatten (map (lambda (ch) (gather-tree ch #:leafs-only leafs-only #:ignore-outer ignore))
                          (node/int/op-children n)))]
           
           [(node/fmla/pred-spacer? n)
-           (gather-tree (node/fmla/pred-spacer-expanded n) #:leafs-only leafs-only)]
+           (gather-tree (node/fmla/pred-spacer-expanded n) #:leafs-only leafs-only #:ignore-outer ignore)]
           [(node/expr/fun-spacer? n)
-           (gather-tree (node/expr/fun-spacer-expanded n) #:leafs-only leafs-only)]
+           (gather-tree (node/expr/fun-spacer-expanded n) #:leafs-only leafs-only #:ignore-outer ignore)]
+          [(node/formula/multiplicity? n)
+           (gather-tree (node/formula/multiplicity-expr n) #:leafs-only leafs-only #:ignore-outer ignore)]
+          [(node/formula/sealed? n)
+           ; for sealed AST nodes, the inner formula is contained in the info field
+           (gather-tree (node-info n) #:leafs-only leafs-only #:ignore-outer ignore)]
 
           [(node/formula/multiplicity? n)
-           (gather-tree (node/formula/multiplicity-expr n) #:leafs-only leafs-only)]
-          [(node/formula/quantified? n)
-           ; TODO: decls
-           (gather-tree (node/formula/quantified-formula n) #:leafs-only leafs-only)]
+           (gather-tree (node/formula/multiplicity-expr n) #:leafs-only leafs-only #:ignore-outer ignore)]
+          [(or (node/formula/quantified? n)
+               (node/expr/comprehension? n)
+               (node/int/sum-quant? n))
+           (gather-quant-helper n)]
 
           ;; TODO: other cases
           [else (list n)]))
-  (if leafs-only
-      descendents
-      (cons n descendents)))
+  (cond [leafs-only descendents]
+        [ignore-outer descendents] 
+        [else (cons n descendents)]))
 
 (define (print-one-per-line l)
   (cond [(not (list l)) (printf "  ~a~n" l)]
@@ -43,15 +74,19 @@
 
 
 ; Confirm that the syntax location information for all nodes refers to the proper module
-(define (check-full-ast-srclocs root-ast sub-path-str)
-  (for ([n (gather-tree root-ast #:leafs-only #f)])
+; The `ignore-outer` parameter allows the caller to ignore the source location of outermost
+; expressions, since that will be captured in _this_ module. Look instead at subexpressions.
+; (Recommended for direct pred invocations: *2* layers to ignore (spacer and outer conjunction).
+(define (check-full-ast-srclocs root-ast sub-path-str #:ignore-outer [ignore-outer 0])
+  (for ([n (gather-tree root-ast #:leafs-only #f #:ignore-outer ignore-outer)])
     (define loc (nodeinfo-loc (node-info n)))
+    ;(printf "~a~n" loc)
     (define source-path-correct
       (string-contains?
        (path->string (srcloc-source loc))
        sub-path-str))
     (unless source-path-correct 
-      (printf "     ~a: ~a~n" n loc))
+      (printf "    Source path unexpected for:~n ~a~n~a~n" n loc))
     ; Comment out for now, avoid unpleasant flickering spam
     ;(check-true source-path-correct)
     ))
@@ -68,13 +103,14 @@
 ;(require (only-in "../forge/library/reachable.frg" reach6))
 ;(check-full-ast-srclocs reach6 "/forge/library/reachable.frg")
 
-(require (only-in "../forge/formulas/booleanFormulaOperators.rkt" Implies And Or Not))
-(check-full-ast-srclocs Implies  "/forge/formulas/booleanFormulaOperators.rkt")
-(check-full-ast-srclocs And  "/forge/formulas/booleanFormulaOperators.rkt")
-(check-full-ast-srclocs Or  "/forge/formulas/booleanFormulaOperators.rkt")
-(check-full-ast-srclocs Not  "/forge/formulas/booleanFormulaOperators.rkt")
+;(require (only-in "../forge/formulas/booleanFormulaOperators.rkt" Implies And Or Not))
+;(check-full-ast-srclocs Implies  "/forge/formulas/booleanFormulaOperators.rkt" #:ignore-outer 2)
+;(check-full-ast-srclocs And  "/forge/formulas/booleanFormulaOperators.rkt" #:ignore-outer 2)
+;(check-full-ast-srclocs Or  "/forge/formulas/booleanFormulaOperators.rkt" #:ignore-outer 2)
+;(check-full-ast-srclocs Not  "/forge/formulas/booleanFormulaOperators.rkt" #:ignore-outer 2)
 
-
+(require (only-in "../forge/examples/sudoku.rkt" generatePuzzle))
+(check-full-ast-srclocs generatePuzzle "sudoku.rkt" #:ignore-outer 2)
 
 ;; TODO: check run parameters as well (catch instances...) 
 ;; TODO: other examples
@@ -116,9 +152,14 @@
 ;; PRED ;;
 (define pvdReachesEverything (reachesEverything Providence))
 (check-true (node? pvdReachesEverything))
-(printf "~a~n" (nodeinfo-loc (node-info pvdReachesEverything)))
+;(printf "~npvdReachesEverything: ~a~n" (nodeinfo-loc (node-info pvdReachesEverything)))
+(check-equal? 153
+              (srcloc-line (nodeinfo-loc (node-info pvdReachesEverything))))
+              
 
 ;; FUN ;;
 (define twoHopsFromProvidence (twoHopsAway Providence))
 (check-true (node? twoHopsFromProvidence))
-(printf "~a~n" (nodeinfo-loc (node-info twoHopsFromProvidence)))
+;(printf "~ntopHopsFromProvidence: ~a~n" (nodeinfo-loc (node-info twoHopsFromProvidence)))
+(check-equal? 161
+              (srcloc-line (nodeinfo-loc (node-info twoHopsFromProvidence))))


### PR DESCRIPTION
When declaring `fun`s and `pred`s, these now expand to syntax that captures source location from the *use* site, rather than the declaration site.