### PR TITLE
Fix: better handling for multiple-tests

### DIFF
--- a/forge/send-to-kodkod.rkt
+++ b/forge/send-to-kodkod.rkt
@@ -343,8 +343,13 @@
   
   ; Print solve
   (define (get-next-model [mode ""])
+    ; If the solver isn't running at all, error:
     (unless (is-running?)
       (raise-user-error "KodKod server is not running."))
+    ; If the solver is running, but this specific run ID is closed, user error
+    (when (is-run-closed? run-name)
+      (raise-user-error (format "Run ~a has been closed." run-name)))
+    
     (pardinus-print (pardinus:solve run-name mode))
     (define result (translate-from-kodkod-cli
                     'run 

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -641,7 +641,7 @@
             ; violates the sig/field declarations.
             #,(syntax/loc stx (run double-check-name #:preds [] #:bounds [bounds ...]))
             (define double-check-instance (tree:get-value (Run-result double-check-name)))
-            (close-run double-check-instance) ;; always close the double-check run immediately
+            (close-run double-check-name) ;; always close the double-check run immediately
             
             (if (Sat? double-check-instance)
                 (report-test-failure #:name 'name #:msg (format "Invalid example '~a'; the instance specified does not satisfy the given predicate." 'name)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -1006,8 +1006,10 @@
                                            delayed-test-failures))]
         
         [else
-         ; Raise a Forge error and stop execution.
-         ; ***** TODO: does this open Sterling properly? (Likely not)
+         ; Raise a Forge error and stop execution; show Sterling if enabled.
+         (when (>= (get-verbosity) 1)
+           (printf "Test ~a failed. Opening Sterling (if able) and stopping.~n" name))
+         (true-display run)
          (raise-forge-error #:msg msg #:context context)]))
 
 ; To be run at the very end of the Forge execution; reports test failures and opens

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -998,9 +998,13 @@
   (cond [(not (equal? (get-option run 'test_keep) 'first))
          (unless (equal? (get-verbosity) 0)
            (printf "Test ~a failed. Continuing to run and will report details at the end.~n" name))
+         ; close previous failure run, since we are keeping only the final failure for Sterling
+         (unless (empty? delayed-test-failures)
+           (close-run (test-failure-run (first delayed-test-failures))))
+         ; then add this failure to the queue
          (set! delayed-test-failures (cons (test-failure name msg context instance run)
                                            delayed-test-failures))]
-        ;; ***** TODO: close prior failing test runs
+        
         [else
          ; Raise a Forge error and stop execution.
          ; ***** TODO: does this open Sterling properly? (Likely not)
@@ -1027,8 +1031,8 @@
                                      (format "Sterling disabled, so reporting raw instance data:~n~a" instance)
                                      (format "Running Sterling to show instance generated, if any.~n~a"
                                              (if (equal? failure last-failure)
-                                                 "Solver is active; evaluator and next are available.~n"
-                                                 "For all but the final test failure, the solver was closed to save memory; evaluator and next are unavailable.~n"))))
+                                                 "Solver is active; evaluator and next are available."
+                                                 "For all but the final test failure, the solver was closed to save memory; evaluator and next are unavailable."))))
     (raise-forge-error #:msg (format "~a ~a~n~n" msg sterling-or-instance)
                        #:context context
                        #:raise? #f)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -1017,7 +1017,7 @@
 (define (output-all-test-failures)
   ; In order, for each failure:  
   (define failures (remove-duplicates (reverse delayed-test-failures)))
-  (unless (empty? failures)
+  (unless (or (< (get-verbosity) 1) (empty? failures))
     (printf "~nSome tests failed. Reporting failures in order:~n~n" ))
 
   (define last-failure (if (empty? failures) #f (last failures)))

--- a/forge/tests/error/bsl_multiple_failures.frg
+++ b/forge/tests/error/bsl_multiple_failures.frg
@@ -1,6 +1,6 @@
 #lang forge/bsl
 option run_sterling off
-
+option test_keep last
 option verbose 0
 
 sig Node {

--- a/forge/tests/error/multiple-positive-examples-failing.frg
+++ b/forge/tests/error/multiple-positive-examples-failing.frg
@@ -1,5 +1,6 @@
 #lang forge
 option run_sterling off
+option test_keep last
 option verbose 0 
 
 -- Regression test to confirm that the "double-check" done in example tests 

--- a/forge/tests/error/multiple_test_failures.frg
+++ b/forge/tests/error/multiple_test_failures.frg
@@ -1,6 +1,7 @@
 #lang forge
 
 option run_sterling off
+option test_keep last
 option verbose 0
 
 

--- a/forge/tests/error/properties_undirected_tree_underconstraint_multiple_errors.frg
+++ b/forge/tests/error/properties_undirected_tree_underconstraint_multiple_errors.frg
@@ -1,5 +1,6 @@
 #lang forge
 option run_sterling off
+option test_keep last
 option verbose 0
 
 sig Node {edges: set Node}

--- a/forge/tests/error/unstated_bounds.frg
+++ b/forge/tests/error/unstated_bounds.frg
@@ -1,0 +1,11 @@
+#lang forge 
+
+// Detect when sufficient bounds have not been provided. 
+
+sig Match {}
+sig B, C extends Match {} 
+
+test expect {
+    should_error: {} for exactly 4 B, 3 C is sat
+}
+

--- a/forge/tests/forge-core/other/test_behavior_first.rkt
+++ b/forge/tests/forge-core/other/test_behavior_first.rkt
@@ -1,0 +1,40 @@
+#lang forge/core
+
+; Confirm that test runs are closed or kept open as expected. 
+; (This is related to multiple_runs.rkt, but has a different focus.)
+
+(require (only-in rackunit check-eq? check-not-eq? check-exn check-not-exn check-true))
+(set-option! 'verbose 0)
+; Default:
+;(set-option! 'test_keep 'first) 
+
+(sig A)
+(sig B)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Default option: 'test_keep is 'first
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; This test should fail and produce an exception immediately in 'first mode: 
+(check-exn #rx"Failed test sat-run-A."
+           (lambda () (test sat-run-A
+                            #:preds [(some A) (no B)]
+                            #:expect unsat)))
+
+; This is not bound to an accessible identifier, but it _is_ kept in the state:
+(define local-sat-run-A (hash-ref (forge:State-runmap forge:curr-state) 'sat-run-A))
+; The test run should remain open, so that Sterling's evaluator is available, etc.
+; DO NOT USE is-running?; that is for the solver process as a whole.
+(check-true (forge:is-sat? local-sat-run-A))
+(check-true (not (forge:is-run-closed? local-sat-run-A)))
+
+;;;;;;;;;;;;;;;;;;;;;
+
+; This test should pass, and its run should be closed immediately.
+(check-not-exn 
+ (lambda () (test sat-run-B
+                  #:preds [(some A) (no B)]
+                  #:expect sat)))
+(define local-sat-run-B (hash-ref (forge:State-runmap forge:curr-state) 'sat-run-B))
+(check-true (forge:is-sat? local-sat-run-B))
+(check-true (forge:is-run-closed? local-sat-run-B))

--- a/forge/tests/forge-core/other/test_behavior_first.rkt
+++ b/forge/tests/forge-core/other/test_behavior_first.rkt
@@ -4,8 +4,10 @@
 ; (This is related to multiple_runs.rkt, but has a different focus.)
 
 (require (only-in rackunit check-eq? check-not-eq? check-exn check-not-exn check-true))
-;(set-option! 'verbose 1)
-; Default:
+(set-option! 'verbose 0)
+(set-option! 'run_sterling 'off)
+
+; 'first is the default, so no need to run this line:
 ;(set-option! 'test_keep 'first) 
 
 (sig A)

--- a/forge/tests/forge-core/other/test_behavior_first.rkt
+++ b/forge/tests/forge-core/other/test_behavior_first.rkt
@@ -4,7 +4,7 @@
 ; (This is related to multiple_runs.rkt, but has a different focus.)
 
 (require (only-in rackunit check-eq? check-not-eq? check-exn check-not-exn check-true))
-(set-option! 'verbose 0)
+;(set-option! 'verbose 1)
 ; Default:
 ;(set-option! 'test_keep 'first) 
 

--- a/forge/tests/forge-core/other/test_behavior_last.rkt
+++ b/forge/tests/forge-core/other/test_behavior_last.rkt
@@ -1,0 +1,39 @@
+#lang forge/core
+
+; Confirm that test runs are closed or kept open as expected. 
+; (This is related to multiple_runs.rkt, but has a different focus.)
+
+(require (only-in rackunit check-eq? check-not-eq? check-exn check-not-exn check-true))
+(set-option! 'verbose 0)
+
+; Not the default:
+(set-option! 'test_keep 'last) 
+
+(sig A)
+(sig B)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Modified option: 'test_keep is 'last
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; This test should fail, but not immediately produce an exception:
+(check-not-exn
+ (lambda () (test sat-run-A
+                  #:preds [(some A) (no B)]
+                  #:expect unsat)))
+; Same with this test. 
+(check-not-exn
+ (lambda () (test sat-run-B
+                  #:preds [(some A) (no B)]
+                  #:expect unsat)))
+
+; This is not bound to an accessible identifier, but it _is_ kept in the state:
+(define local-sat-run-A (hash-ref (forge:State-runmap forge:curr-state) 'sat-run-A))
+(define local-sat-run-B (hash-ref (forge:State-runmap forge:curr-state) 'sat-run-B))
+; Under the 'last option, the first run should have been closed
+; DO NOT USE is-running?; that is for the solver process as a whole.
+; Under the 'last option, the second run should remain open (since it is the last failure)
+(check-true (forge:is-sat? local-sat-run-A))
+(check-true (forge:is-run-closed? local-sat-run-A)) 
+(check-true (forge:is-sat? local-sat-run-B))
+(check-true (not (forge:is-run-closed? local-sat-run-B)))

--- a/forge/tests/forge-core/other/test_behavior_last.rkt
+++ b/forge/tests/forge-core/other/test_behavior_last.rkt
@@ -5,6 +5,7 @@
 
 (require (only-in rackunit check-eq? check-not-eq? check-exn check-not-exn check-true))
 (set-option! 'verbose 0)
+(set-option! 'run_sterling 'off)
 
 ; Not the default:
 (set-option! 'test_keep 'last) 
@@ -37,3 +38,7 @@
 (check-true (forge:is-run-closed? local-sat-run-A)) 
 (check-true (forge:is-sat? local-sat-run-B))
 (check-true (not (forge:is-run-closed? local-sat-run-B)))
+
+; This is, however, not calling the failure-reporter that the Forge surface languages
+; invoke at the end of their execution -- since this is forge/core.
+; (output-all-test-failures)


### PR DESCRIPTION
Added a new option, `test_keep`, with 2 values:
* `first` (default): stop on first test failure with exception. Open Sterling (if available) first. 
* `last`: keep running _all_ tests, and report the set of failing tests at end. Open Sterling, and keep the run open only for the _final_ failing test. Other failures will be reported, but Sterling will not open and those runs will not remain active in the solver. 