### PR TITLE
feat: xor operator (macro, surface); tests

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -66,6 +66,7 @@
    ["&" (token+ 'AMP-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["+" (token+ 'PLUS-TOK "" lexeme "" lexeme-start lexeme-end)]
    [(or "<=" "=<") (token+ 'LEQ-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["xor" (token+ 'XOR-TOK "" lexeme "" lexeme-start lexeme-end)]
    [(or "!" "not") (token+ 'NEG-TOK "" lexeme "" lexeme-start lexeme-end)]
    [(or "||" "or") (token+ 'OR-TOK "" lexeme "" lexeme-start lexeme-end)]
    [(or "&&" "and") (token+ 'AND-TOK "" lexeme "" lexeme-start lexeme-end)]
@@ -205,6 +206,7 @@
            "iden"
            "iff"
            "implies"
+           "xor"
            "in"
            "ni"
            "is"

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -181,7 +181,8 @@ Expr    : @Expr1
         | LET-TOK LetDeclList BlockOrBar
         | BIND-TOK LetDeclList BlockOrBar
         | Quant DISJ-TOK? QuantDeclList BlockOrBar
-Expr1   : @Expr2  | Expr1 OR-TOK Expr2
+Expr1   : @Expr1.5  | Expr1 OR-TOK Expr1.5
+Expr1.5 : @Expr2    | Expr1.5 XOR-TOK Expr2
 Expr2   : @Expr3  | Expr2 IFF-TOK Expr3
 ;; right assoc
 Expr3   : @Expr4  | Expr4 IMP-TOK Expr3 (ELSE-TOK Expr3)?        

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -732,7 +732,7 @@
       #:attr symbol (syntax/loc #'q sum-quant)))
 
   (define-syntax-class ExprClass
-    (pattern ((~or (~datum Expr) (~datum Expr1) (~datum Expr2) (~datum Expr3)
+    (pattern ((~or (~datum Expr) (~datum Expr1) (~datum Expr1.5) (~datum Expr2) (~datum Expr3)
                    (~datum Expr4) (~datum Expr4.5) (~datum Expr5) (~datum Expr6) (~datum Expr7) (~datum Expr7.5)
                    (~datum Expr8) (~datum Expr9) (~datum Expr10) (~datum Expr11)
                    (~datum Expr12) (~datum Expr13) (~datum Expr14) (~datum Expr15)
@@ -1170,6 +1170,13 @@
                  [expr2 (my-expand #'expr2)])
      (syntax/loc stx (|| expr1 expr2)))]
 
+    ; exclusive OR
+    [((~datum Expr) expr1:ExprClass "xor" expr2:ExprClass)
+     (with-syntax ([expr1 (my-expand #'expr1)]
+                   [expr2 (my-expand #'expr2)])
+       (syntax/loc stx (xor expr1 expr2)))]
+
+    
   [((~datum Expr) expr1:ExprClass (~or "iff" "<=>") expr2:ExprClass)
    (with-syntax ([expr1 (my-expand #'expr1)]
                  [expr2 (my-expand #'expr2)])
@@ -1457,6 +1464,7 @@
              [((~var macro-id id) . pattern) pattern-directive ... (syntax/loc stx template)]))))]))
 
 (dsm-keep (Expr1 stx ...) (Expr stx ...))
+(dsm-keep (Expr1.5 stx ...) (Expr stx ...))
 (dsm-keep (Expr2 stx ...) (Expr stx ...))
 (dsm-keep (Expr3 stx ...) (Expr stx ...))
 (dsm-keep (Expr4 stx ...) (Expr stx ...))

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -82,7 +82,7 @@
 (provide (prefix-out forge: (all-from-out forge/sigs-structs)))
 
 ; Export these from structs without forge: prefix
-(provide implies iff <=> ifte int>= int<= ni != !in !ni <: :>)
+(provide implies iff <=> ifte int>= int<= ni != !in !ni <: :> xor)
 (provide Int succ min max)
 
 ; Export these from sigs-functional

--- a/forge/tests/forge-core/formulas/booleanFormulaOperators.rkt
+++ b/forge/tests/forge-core/formulas/booleanFormulaOperators.rkt
@@ -24,6 +24,12 @@
     (|| false true)
     (! (|| false false)))
 
+(pred Xor
+    (! (xor true true))
+    (xor true false)
+    (xor false true)
+    (! (xor false false)))
+
 (pred Implies ; =>, implies, <=>, iff, ifte
     (=> true true)
     (! (=> true false))
@@ -65,6 +71,9 @@
       #:expect theorem)
 (test orOps 
       #:preds [Or]
+      #:expect theorem)
+(test xorOps 
+      #:preds [Xor]
       #:expect theorem)
 (test impliesOps 
       #:preds [Implies]

--- a/forge/tests/forge/formulas/booleanFormulaOperators.frg
+++ b/forge/tests/forge/formulas/booleanFormulaOperators.frg
@@ -45,6 +45,13 @@ pred Or { -- ||, or
     not (False or False)
 }
 
+pred Xor { 
+    not (True xor True)
+    True xor False
+    False xor True
+    not (False xor False)
+}
+
 pred Implies { -- =>, implies, <=>, iff, => else, implies else
     True => True
     not (True => False)
@@ -89,6 +96,7 @@ test expect BooleanFormulaOperators {
     NotOps : Not is theorem
     AndOps : And is theorem
     OrOps : Or is theorem
+    XorOps : Xor is theorem
     ImpliesOps : Implies is theorem
 }
 


### PR DESCRIPTION
Adding xor operator, pair-programming exercise with Karim!

The operator has no AST node; it's implemented via a macro to (or (and a !b) (and !a b)).