### PR TITLE
Add command-line argument support via racket

### DIFF
--- a/forge/examples/sudoku_opt_viz/sudoku_unrolled.frg
+++ b/forge/examples/sudoku_opt_viz/sudoku_unrolled.frg
@@ -48,7 +48,7 @@ fun get_grid[s: BoardState, subgrid: Int]: set Int {
         s.board[rows][cols]
 }
 
-pred solution[s: PuzzleState] {
+pred solution[s: BoardState] {
     -- ** Rows and Columns **
     -- don't use #... = 9 here; instead something like:
     all r: values | s.board[r][Int] = values

--- a/forge/examples/sudoku_opt_viz/sudoku_with_inst.frg
+++ b/forge/examples/sudoku_opt_viz/sudoku_with_inst.frg
@@ -45,7 +45,7 @@ fun values: set Int {
     1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9
 }
 
-pred solution[s: PuzzleState] {
+pred solution[s: BoardState] {
     -- ** Rows and Columns **
     -- don't use #... = 9 here; instead something like:
     all r: values | s.board[r][Int] = values

--- a/forge/examples/sudoku_opt_viz/sudoku_with_inst_2.frg
+++ b/forge/examples/sudoku_opt_viz/sudoku_with_inst_2.frg
@@ -46,7 +46,7 @@ fun get_grid[s: BoardState, row_offset, col_offset: Int]: set Int {
         s.board[rows][cols]
 }
 
-pred solution[s: PuzzleState] {
+pred solution[s: BoardState] {
     -- ** Rows and Columns **
     -- don't use #... = 9 here; instead something like:
     all r: Helper.values | s.board[r][Int] = Helper.values

--- a/forge/run-tests.sh
+++ b/forge/run-tests.sh
@@ -35,8 +35,9 @@ for testFile in $testFiles; do
     current=`date "+%X"`
     echo -e "\nRunning $testFile ($current)"
 
-    #start=`date +%s`    
-    racket $testFile > /dev/null
+    #start=`date +%s` 
+    # Use permanent (-O) option flag to always disable Sterling   
+    racket $testFile -O run_sterling \'off > /dev/null
     #end=`date +%s`
     #echo -e "Testfile took $((end-start)) seconds."
     testExitCode=$?


### PR DESCRIPTION
Prototype command-line support for setting options. There are two flags supported at the moment: -o and -O (lower and uppercase). 

The lowercase -o will set an initial option value, but will be OVERRIDDEN by file-level option statements. E.g., this at the command line (note the need to escape the backquote):
`racket ring_of_lights.frg -o run_sterling \'off -o verbose 1`
* will NOT run sterling (because the example doesn't give a value for that option)
* WILL give verbose 5 output (because the example gives a value of 5 for that option)

In contrast, the uppercase -O will set the initial option value and disallow it changing. E.g.,
`racket ring_of_lights.frg -o run_sterling \'off -O verbose 1`
will give verbose 1 output. 

The `run-tests.sh` script has been modified to give`-O run_sterling \'off`, which means that it can now be used vs. the `examples` folder for additional testing, as the `run` commands in those example models will not open browser tabs.