### PR TITLE
Satisfiability Assertions

### DIFF
--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -96,8 +96,6 @@ Typescope : EXACTLY-TOK? Number QualName
 Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
-
-;TODO: Should this allow SAT AND? UNSAT?
 SatisfiabilityDecl : /ASSERT-TOK Name /IS-TOK (SAT-TOK | UNSAT-TOK | FORGE_ERROR-TOK) Scope? (/FOR-TOK Bounds)? 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 
 QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK DISJ-TOK? QuantDeclList /BAR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -50,6 +50,7 @@ Import : /OPEN-TOK QualName (LEFT-SQUARE-TOK QualNameList RIGHT-SQUARE-TOK)? (AS
           | ExampleDecl 
           | PropertyDecl
           | QuantifiedPropertyDecl
+          | SatisfiabilityDecl
           | TestSuiteDecl
 
 ; NOTE: When extending sigs with "in" (subset sigs) is implemented,
@@ -96,12 +97,15 @@ Const : NONE-TOK | UNIV-TOK | IDEN-TOK
       | MINUS-TOK? Number 
 
 
+;TODO: Should this allow SAT AND? UNSAT?
+SatisfiabilityDecl : /ASSERT-TOK Name /IS-TOK (SAT-TOK | UNSAT-TOK | FORGE_ERROR-TOK) Scope? (/FOR-TOK Bounds)? 
 PropertyDecl : /ASSERT-TOK Name /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name Scope? (/FOR-TOK Bounds)? 
 QuantifiedPropertyDecl : /ASSERT-TOK /ALL-TOK DISJ-TOK? QuantDeclList /BAR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)?  /IS-TOK (SUFFICIENT-TOK | NECESSARY-TOK) /FOR-TOK Name (/LEFT-SQUARE-TOK ExprList /RIGHT-SQUARE-TOK)? Scope? (/FOR-TOK Bounds)? 
 
+
 TestSuiteDecl : /TEST-TOK /SUITE-TOK /FOR-TOK Name /LEFT-CURLY-TOK TestConstruct* /RIGHT-CURLY-TOK
 
-@TestConstruct : ExampleDecl | TestExpectDecl | PropertyDecl | QuantifiedPropertyDecl
+@TestConstruct : ExampleDecl | TestExpectDecl | PropertyDecl | QuantifiedPropertyDecl | SatisfiabilityDecl
 
 
 # UnOp : Mult

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -121,6 +121,7 @@
     (pattern decl:TestExpectDeclClass)
     (pattern decl:PropertyDeclClass)
     (pattern decl:QuantifiedPropertyDeclClass)
+    (pattern decl:SatisfiabilityDeclClass)
     (pattern decl:TestSuiteDeclClass)
     (pattern decl:SexprDeclClass)
     ; (pattern decl:BreakDeclClass)
@@ -353,7 +354,8 @@
     (pattern decl:ExampleDeclClass)
     (pattern decl:TestExpectDeclClass)
     (pattern decl:PropertyDeclClass)
-    (pattern decl:QuantifiedPropertyDeclClass))
+    (pattern decl:QuantifiedPropertyDeclClass)
+    (pattern decl:SatisfiabilityDeclClass))
 
   (define-syntax-class PropertyDeclClass
     #:attributes (prop-name pred-name constraint-type scope bounds)
@@ -390,6 +392,20 @@
       #:with constraint-type (string->symbol (syntax-e #'ct))
       #:with scope (if (attribute -scope) #'-scope.translate #'())
       #:with bounds (if (attribute -bounds) #'-bounds.translate #'())))
+
+
+  (define-syntax-class SatisfiabilityDeclClass
+    #:attributes (pred-name expected scope bounds)
+    (pattern ((~datum SatisfiabilityDecl)
+              -pred-name:NameClass
+              (~and (~or "sat" "unsat" "forge_error") ct)
+              (~optional -scope:ScopeClass)
+              (~optional -bounds:BoundsClass))
+      #:with pred-name #'-pred-name.name)
+      #:with expected (string->symbol (syntax-e #'ct))
+      #:with scope (if (attribute -scope) #'-scope.translate #'())
+      #:with bounds (if (attribute -bounds) #'-bounds.translate #'()))
+
 
 
   (define-syntax-class TestSuiteDeclClass
@@ -1046,6 +1062,19 @@
          #:scope qpd.scope
          #:bounds qpd.bounds
          #:expect theorem )))]))
+
+
+(define-syntax (SatisfiabilityDecl stx)
+  (syntax-parse stx
+  [sd:SatisfiabilityDeclClass 
+   #:with test_name (format-id stx "Assertion_~a_is_sat" #'sd.pred-name )
+   (syntax/loc stx
+      (test
+        test_name
+        #:preds [sd.pred-name]
+        #:scope sd.scope
+        #:bounds sd.bounds
+        #:expect sd.expected ))]))
 
 ;; Quick and dirty static check to ensure a test
 ;; references a predicate.

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1065,7 +1065,7 @@
 (define-syntax (SatisfiabilityDecl stx)
   (syntax-parse stx
   [sd:SatisfiabilityDeclClass 
-   #:with test_name (format-id stx "Assertion_~a_is_~a" #'sd.pred-name #'sd.expected)
+   #:with test_name (format-id stx "Assertion_~a_is_~a_~a" #'sd.pred-name #'sd.expected (make-temporary-name stx))
    (syntax/loc stx
       (test
         test_name

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -393,19 +393,17 @@
       #:with scope (if (attribute -scope) #'-scope.translate #'())
       #:with bounds (if (attribute -bounds) #'-bounds.translate #'())))
 
-
-  (define-syntax-class SatisfiabilityDeclClass
-    #:attributes (pred-name expected scope bounds)
-    (pattern ((~datum SatisfiabilityDecl)
-              -pred-name:NameClass
-              (~and (~or "sat" "unsat" "forge_error") ct)
-              (~optional -scope:ScopeClass)
-              (~optional -bounds:BoundsClass))
-      #:with pred-name #'-pred-name.name)
-      #:with expected (string->symbol (syntax-e #'ct))
-      #:with scope (if (attribute -scope) #'-scope.translate #'())
-      #:with bounds (if (attribute -bounds) #'-bounds.translate #'()))
-
+(define-syntax-class SatisfiabilityDeclClass
+  #:attributes (pred-name expected scope bounds)
+  (pattern ((~datum SatisfiabilityDecl)
+            -pred-name:NameClass
+            (~and (~or "sat" "unsat" "forge_error") ct)
+            (~optional -scope:ScopeClass)
+            (~optional -bounds:BoundsClass))
+    #:with pred-name #'-pred-name.name
+    #:with expected (string->symbol (syntax-e #'ct))
+    #:with scope (if (attribute -scope) #'-scope.translate #'())
+    #:with bounds (if (attribute -bounds) #'-bounds.translate #'())))
 
 
   (define-syntax-class TestSuiteDeclClass

--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -1067,7 +1067,7 @@
 (define-syntax (SatisfiabilityDecl stx)
   (syntax-parse stx
   [sd:SatisfiabilityDeclClass 
-   #:with test_name (format-id stx "Assertion_~a_is_sat" #'sd.pred-name )
+   #:with test_name (format-id stx "Assertion_~a_is_~a" #'sd.pred-name #'sd.expected)
    (syntax/loc stx
       (test
         test_name

--- a/forge/tests/forge/other/satisfaction-assertions.frg
+++ b/forge/tests/forge/other/satisfaction-assertions.frg
@@ -17,9 +17,16 @@ pred impossible {
     not isDirectedTree
 }
 
+pred producesErr {
+
+    Node in Node->Node
+}
+
 
 assert isDirectedTree is sat
 assert impossible is unsat
+
+assert producesErr is forge_error
 
 test suite for isDirectedTree {
     assert isDirectedTree is sat for 3 Node

--- a/forge/tests/forge/other/satisfaction-assertions.frg
+++ b/forge/tests/forge/other/satisfaction-assertions.frg
@@ -1,5 +1,6 @@
 #lang forge
 option run_sterling off
+option verbose 0
 
 sig NonNode {}
 sig Node {edges: set Node}
@@ -11,28 +12,20 @@ pred isDirectedTree {
 	lone Node or Node in edges.Node + Node.edges -- Either one node or every node has either a child or a parent.
 }
 
-
 pred impossible {
     isDirectedTree
     not isDirectedTree
 }
 
 pred producesErr {
-
     Node in Node->Node
 }
 
-
 assert isDirectedTree is sat
 assert impossible is unsat
-
 assert producesErr is forge_error
 
-test suite for isDirectedTree {
-    assert isDirectedTree is sat for 3 Node
-
-}
-
-test suite for impossible {
-    assert impossible is unsat for exactly 1 Node
-}
+-- Test in suite context
+test suite for isDirectedTree { assert isDirectedTree is sat for 3 Node }
+test suite for impossible { assert impossible is unsat for exactly 1 Node }
+test suite for producesErr { assert producesErr is forge_error for exactly 1 Node }

--- a/forge/tests/forge/other/satisfaction-assertions.frg
+++ b/forge/tests/forge/other/satisfaction-assertions.frg
@@ -1,0 +1,29 @@
+#lang forge
+option run_sterling off
+
+sig NonNode {}
+sig Node {edges: set Node}
+
+pred isDirectedTree {
+	edges.~edges in iden -- Injective, each child has at most one parent
+	lone edges.Node - Node.edges -- At most one element that does not have a parent
+	no (^edges & iden) -- No loops
+	lone Node or Node in edges.Node + Node.edges -- Either one node or every node has either a child or a parent.
+}
+
+
+pred impossible {
+    isDirectedTree
+    not isDirectedTree
+}
+
+assert isDirectedTree is sat
+assert impossible is unsat
+
+test suite for isDirectedTree {
+    assert isDirectedTree is sat for 3 Node
+}
+
+test suite for impossible {
+    assert impossible is unsat for exactly 1 Node
+}

--- a/forge/tests/forge/other/satisfaction-assertions.frg
+++ b/forge/tests/forge/other/satisfaction-assertions.frg
@@ -17,11 +17,13 @@ pred impossible {
     not isDirectedTree
 }
 
+
 assert isDirectedTree is sat
 assert impossible is unsat
 
 test suite for isDirectedTree {
     assert isDirectedTree is sat for 3 Node
+
 }
 
 test suite for impossible {


### PR DESCRIPTION
Adding support for assertions about the satisfiability (or unsatisfiability) for assertions. These take the form:

```
assert <predicatename> is sat
assert <predicatename> is unsat
assert <predicatename> is forge_error
```