### PR TITLE
logging: beware of read failures

### DIFF
--- a/forge/logging/2023/main.rkt
+++ b/forge/logging/2023/main.rkt
@@ -62,8 +62,13 @@
 
 (define (setup language port path)
   (define peek-port (peeking-input-port port))
-  (define project (read peek-port))
-  (define user (read peek-port))
+  (define-values [project user]
+    (let* ((err? (lambda (ee) (or (exn:fail:contract? ee) (exn:fail:read? ee))))
+           (default (lambda (ee) (list #f #f)))
+           (res*
+            (with-handlers ((err? default))
+              (list (read peek-port) (read peek-port)))))
+      (apply values res*)))
   (close-input-port peek-port)
   (if (and (string? project) (string? user))
       (let ((got-data-file? (path-string? (get-log-file))))

--- a/forge/tests/forge/other/logging-ok-with-hashlang-comment.frg
+++ b/forge/tests/forge/other/logging-ok-with-hashlang-comment.frg
@@ -1,0 +1,6 @@
+#lang forge/temporal
+
+// #lang froglet
+
+abstract sig Player {}
+


### PR DESCRIPTION
This program was an error because the logging setup called `read` and would die if it ever saw a `#lang`:

```
#lang forge/temporal

// #lang froglet
```

Use `with-handlers` to avoid.