### PR TITLE
[patch] Detection for cyclic references in pred, fun

### DIFF
--- a/forge/lang/expander.rkt
+++ b/forge/lang/expander.rkt
@@ -919,16 +919,20 @@
 (define-syntax (FunDecl stx)
   (syntax-parse stx
   ; TODO: output type declared is currently being lost
+
+  ; 0-ary function
   [((~datum FunDecl) (~optional (~seq prefix:QualNameClass "."))
                        name:NameClass
                        (~optional output-mult:HelperMultClass)
                        output-expr:ExprClass
                        body:ExprClass)
+   
    (with-syntax ([body #'body])
      (syntax/loc stx (begin
        (~? (raise (format "Prefixes not allowed: ~a" 'prefix)))
        (const name.name body))))]
 
+  ; >0-ary function
   [((~datum FunDecl) (~optional (~seq prefix:QualNameClass "."))
                        name:NameClass
                        decls:ParaDeclsClass

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -441,6 +441,8 @@
       #:attr mexpr #'(mexpr expr (if (> (node/expr-arity expr) 1) 'set 'one))))
   )
 
+(define helpers-enclosing (make-parameter '()))
+
 ; Declare a new predicate
 ; Two cases: one with args, and one with no args
 (define-syntax (pred stx)
@@ -500,8 +502,13 @@
                    (error (format "Argument '~a' to pred ~a was not a Forge expression, integer-expression, or Racket integer. Got ~v instead."
                                   'decls.name 'name decls.name)))
                  ...
-                 (pt.seal (node/fmla/pred-spacer the-info 'name (list (apply-record 'decls.name decls.mexpr decls.name) ...)
-                                                 (&&/info the-info conds ...))))
+                 (when (member 'name (helpers-enclosing))
+                   (raise-forge-error #:msg (format "recursive predicate detected: ~a eventually called itself. The chain of calls involved: ~a.~n"
+                                                    'name (helpers-enclosing))
+                                      #:context the-info))
+                 (parameterize ([helpers-enclosing (cons 'name (helpers-enclosing))])
+                   (pt.seal (node/fmla/pred-spacer the-info 'name (list (apply-record 'decls.name decls.mexpr decls.name) ...)
+                                                   (&&/info the-info conds ...)))))
                
 
                

--- a/forge/tests/forge/other/recursive-error.frg
+++ b/forge/tests/forge/other/recursive-error.frg
@@ -8,20 +8,35 @@
 
 sig A {}
 
--- Can we add some protection at the phase 0 level? What happens with >0 args, where there's a func?
+-- arity 0, immediate cycle
 pred r { r }
--- This is actually hard to manage. So why is pred so permissive?
--- fun f[a: A]: one A { f[a] }
+
+// 1-call cycles, test direct and within boolean expression
 pred r1[a: A] { r1[a] }
 pred r2[a: A] { some a: A | {some a and r2[a]} }
+
+// 2-call cycle
 pred r3x[a: A] { r3y[a] }
 pred r3y[a: A] { r3x[a] }
 
+// 3-call cycle
+pred r4x[a: A] { r4y[a] }
+pred r4y[a: A] { r4z[a] }
+pred r4z[a: A] { r4x[a] }
+
+-- This is actually hard to manage. So why is pred so permissive?
+-- fun f[a: A]: one A { f[a] }
+
+
 option verbose 10
 test expect {
-    --try_recur_pred0: {r} is forge_error
+    --try_recur_pred0: {r} is sat -- forge_error
+    
     try_recur_pred1: {some a: A | r1[a] } is forge_error "r1 eventually called itself"
     try_recur_pred2: {some a: A | r2[a] } is forge_error "r2 eventually called itself"
-    try_recur_pred3: {some a: A | r3x[a] } is sat --forge_error "r2 eventually called itself"
+    try_recur_pred3: {some a: A | r3x[a] } is forge_error "r3x eventually called itself"
+    try_recur_pred4: {some a: A | r4x[a] } is forge_error "r4x eventually called itself"
+
+
     --try_recur_fun: {some f} is forge_error
 }

--- a/forge/tests/forge/other/recursive-error.frg
+++ b/forge/tests/forge/other/recursive-error.frg
@@ -38,8 +38,8 @@ pred r5[a: A] { r }
 pred r6x[a1: A, a2: A] { r6y[a1] }
 pred r6y[a: A] { r6x[a, a] }
 
--- This is actually hard to manage. So why is pred so permissive?
--- fun f[a: A]: one A { f[a] }
+fun f[a: A]: one A { g[a] }
+fun g[a: A]: one A { f[a] }
 
 test expect {
     recur_pred_0arg_self:       {r} is forge_error "r eventually called itself"
@@ -55,6 +55,5 @@ test expect {
     recur_pred_1arg_2arg_2loop: {some a: A | r6y[a] } is forge_error "r6y eventually called itself"
     recur_pred_2arg_1arg_2loop: {some a: A | r6x[a,a] } is forge_error "r6x eventually called itself"
     
-    
-     --try_recur_fun: {some f} is forge_error
+    recur_fun_2loop: {some a: A | f[a]} is forge_error "f eventually called itself"
 }

--- a/forge/tests/forge/other/recursive-error.frg
+++ b/forge/tests/forge/other/recursive-error.frg
@@ -38,8 +38,24 @@ pred r5[a: A] { r }
 pred r6x[a1: A, a2: A] { r6y[a1] }
 pred r6y[a: A] { r6x[a, a] }
 
+
+// 0-arg function is harder to self-loop, 
+// because we get an identifier-ref-before-definition error
+// See the comments in `const` in sigs.rkt.
+//fun i: one A { i }
+//fun j1: one A { j2 }
+//fun j2: one A { j1 }
+
+
+// 1-arg function, self loop
+fun h[a: A]: one A { h[a] }
+// 1-arg functions, 2-call loop
 fun f[a: A]: one A { g[a] }
 fun g[a: A]: one A { f[a] }
+
+
+
+
 
 test expect {
     recur_pred_0arg_self:       {r} is forge_error "r eventually called itself"
@@ -56,4 +72,5 @@ test expect {
     recur_pred_2arg_1arg_2loop: {some a: A | r6x[a,a] } is forge_error "r6x eventually called itself"
     
     recur_fun_2loop: {some a: A | f[a]} is forge_error "f eventually called itself"
+    recur_fun_self:  {some a: A | h[a]} is forge_error "h eventually called itself"
 }

--- a/forge/tests/forge/other/recursive-error.frg
+++ b/forge/tests/forge/other/recursive-error.frg
@@ -1,0 +1,27 @@
+#lang forge/froglet 
+
+/*
+  While syntactically, one can write recursive Forge predicates, this won't 
+  actually have the desired meaning. Alloy has an "unroll depth" for these,
+  but we would like to disable them entirely in this context.
+*/
+
+sig A {}
+
+-- Can we add some protection at the phase 0 level? What happens with >0 args, where there's a func?
+pred r { r }
+-- This is actually hard to manage. So why is pred so permissive?
+-- fun f[a: A]: one A { f[a] }
+pred r1[a: A] { r1[a] }
+pred r2[a: A] { some a: A | {some a and r2[a]} }
+pred r3x[a: A] { r3y[a] }
+pred r3y[a: A] { r3x[a] }
+
+option verbose 10
+test expect {
+    --try_recur_pred0: {r} is forge_error
+    try_recur_pred1: {some a: A | r1[a] } is forge_error "r1 eventually called itself"
+    try_recur_pred2: {some a: A | r2[a] } is forge_error "r2 eventually called itself"
+    try_recur_pred3: {some a: A | r3x[a] } is sat --forge_error "r2 eventually called itself"
+    --try_recur_fun: {some f} is forge_error
+}


### PR DESCRIPTION
Both 0-arg and >0-arg cases pred p definition expand to:
* a function definition p/func that does the cycle checking and AST construction. This function will contain an instance of p that will be expanded, but only once; and 
* a macro definition p that captures use-site information and then invokes p/func.
The crucial change is the "but only once" in the first bullet above. This breaks the cycle of expansion we were seeing for 0-arg predicate cycles. 

1-arg predicates already had this function separation in place, but needed a parameter added to track context.